### PR TITLE
parties: simplified and consistent "Party" designator

### DIFF
--- a/data/tables/parties.md
+++ b/data/tables/parties.md
@@ -1,1946 +1,1946 @@
-| Party                                       | Donation Made To                                                                  | Total Donations |
-| ------------------------------------------- | --------------------------------------------------------------------------------- | --------------- |
-| UAP                                         | United Australia Party                                                            | $83,929,218     |
-| LIB                                         | Liberal Party of Australia                                                        | $55,574,981     |
-| PUP                                         | Palmer United Party                                                               | $35,753,598     |
-| ALP                                         | Australian Labor Party (ALP)                                                      | $34,915,448     |
-| LIB                                         | Liberal Party of Australia - NATIONAL                                             | $20,670,189     |
-| LIB                                         | Liberal Party of Australia, NSW Division                                          | $18,192,167     |
-| ALP                                         | Australian Labor Party (N.S.W. Branch)                                            | $15,829,201     |
-| ALP                                         | Australian Labor Party (N.S.W. Branch) - NSW                                      | $15,000,239     |
-| LIB                                         | Liberal Party of Australia, NSW Division - NSW                                    | $13,184,614     |
-| LIB                                         | Liberal Party of Australia (Victorian Division)                                   | $12,739,546     |
-| LIB                                         | Liberal Party of Australia (Victorian Division) - VIC                             | $12,615,872     |
-| ALP                                         | Australian Labor Party (ALP) - NATIONAL                                           | $12,140,648     |
-| LNP                                         | Liberal National Party of Queensland                                              | $11,515,303     |
-| ALP                                         | Australian Labor Party (Victorian Branch)                                         | $10,666,403     |
-| ALP                                         | Australian Labor Party (Victorian Branch) - VIC                                   | $7,114,197      |
-| NAT                                         | National Party of Australia                                                       | $6,878,898      |
-| ALP                                         | Australian Labor Party (State of Queensland)                                      | $6,822,559      |
-| LIB                                         | Liberal Party of Australia (S.A. Division)                                        | $6,717,450      |
-| LIB                                         | Liberal Party (W.A. Division) Inc.                                                | $6,251,161      |
-| UAP                                         | Clive Palmer's United Australia Party                                             | $5,910,341      |
-| LIB                                         | Liberal Party of Australia - Federal Secretariat                                  | $5,533,148      |
-| LIB                                         | Liberal Party (W.A. Division) Inc. - WA                                           | $5,200,057      |
-| ALP                                         | Australian Labor Party (State of Queensland) - QLD                                | $5,187,884      |
-| ALP                                         | Australian Labor Party (Western Australian Branch)                                | $4,884,058      |
-| LIB                                         | LIB-FED                                                                           | $4,352,901      |
-| ALP                                         | Australian Labor Party (NSW Branch)                                               | $4,273,171      |
-| LIB                                         | Liberal Party (W.A. Division) Inc                                                 | $4,232,588      |
-| ALP                                         | Australian Labor Party - National Secretariat                                     | $3,970,479      |
-| LIB                                         | Liberal Party of Australia (NSW Division)                                         | $3,944,553      |
-| LIB                                         | Liberal Party of Australia - Tasmanian Division                                   | $3,662,588      |
-| ALP                                         | Australian Labor Party (Western Australian Branch) - WA                           | $3,484,631      |
-| LIB                                         | Liberal Party of Australia (VIC Division)                                         | $3,409,175      |
-| LIB                                         | Liberal Party of Australia - Queensland Division - QLD                            | $3,346,916      |
-| LIB                                         | Liberal Party of Australia (S.A. Division) - SA                                   | $2,862,564      |
-| LIB                                         | The Free Enterprise Foundation                                                    | $2,709,019      |
-| NAT                                         | National Party of Australia - NATIONAL                                            | $2,580,935      |
-| ALP                                         | ALP-FED                                                                           | $2,565,899      |
-| ALP                                         | Australian Labor Party (South Australian Branch) - SA                             | $2,562,948      |
-| CEC                                         | Citizens Electoral Council of Australia - NATIONAL                                | $2,507,236      |
-| NAT                                         | National Party of Australia - N.S.W.                                              | $2,441,212      |
-| FFP                                         | Family First Party                                                                | $2,193,200      |
-| ALP                                         | Australian Labor Party (South Australian Branch)                                  | $2,118,194      |
-| LIB                                         | Advance Australia                                                                 | $2,117,000      |
-| GRN                                         | The Australian Greens - Victoria                                                  | $2,107,984      |
-| GRN                                         | The Greens (WA) Inc                                                               | $2,055,498      |
-| ALP                                         | Australian Council of Trade Unions                                                | $2,050,000      |
-| ALP                                         | Australian Labor Party (VIC Branch)                                               | $2,040,940      |
-| LIB                                         | Liberal Party of Australia - Victorian Division                                   | $1,823,430      |
-| ALP                                         | Australian Labor Party (Northern Territory) Branch                                | $1,820,938      |
-| LIB                                         | LIB-NSW                                                                           | $1,797,151      |
-| GRN                                         | GRN-FED                                                                           | $1,700,295      |
-| NAT                                         | National Party of Australia (Queensland) - QLD                                    | $1,593,857      |
-| NAT                                         | National Party of Australia (Queensland)                                          | $1,584,011      |
-| NAT                                         | National Party of Australia - N.S.W. - NSW                                        | $1,578,766      |
-| LNP                                         | LNP-QLD                                                                           | $1,568,489      |
-| LIB                                         | Liberal Party of Australia - Queensland Division                                  | $1,565,813      |
-| CLP                                         | Country Liberals (Northern Territory)                                             | $1,554,382      |
-| NAT                                         | National Party of Australia (WA) Inc                                              | $1,548,931      |
-| CEC                                         | Citizens Electoral Council of Australia                                           | $1,547,924      |
-| ALP                                         | ALP-NSW                                                                           | $1,423,456      |
-| NAT                                         | National Party of Australia - Victoria                                            | $1,401,609      |
-| LIB                                         | LIB-SA                                                                            | $1,347,545      |
-| ALP                                         | Australian Labor Party (ACT Branch) - ACT                                         | $1,285,949      |
-| GRN                                         | Australian Greens                                                                 | $1,266,983      |
-| SPP                                         | #Sustainable Australia                                                            | $1,187,279      |
-| KAP                                         | Katter's Australian Party                                                         | $1,160,659      |
-| LIB                                         | Liberal Party of Australia (Federal Secretariat)                                  | $1,044,288      |
-| ALP                                         | Australian Labor Party                                                            | $1,030,165      |
-| ALP                                         | ALP National Secretariat                                                          | $1,013,048      |
-| ALP                                         | ALP                                                                               | $1,004,672      |
-| GRN                                         | The Greens NSW                                                                    | $1,001,888      |
-| ALP                                         | ALP - National Secretariate                                                       | $1,000,000      |
-| LIB                                         | Liberal Party of Australia (SA Division)                                          | $984,751        |
-| ALP                                         | Australian Labor Party (National Secretariat)                                     | $977,186        |
-| LIB                                         | LIB                                                                               | $955,964        |
-| NAT                                         | National Party of Australia (WA) Inc - WA                                         | $903,085        |
-| FFP                                         | Family First Party - NATIONAL                                                     | $885,670        |
-| LIB                                         | Liberal Party of Australia (WA Division) Inc                                      | $880,742        |
-| ALP                                         | Australian Labor Party - State of Queensland                                      | $871,618        |
-| CEC                                         | CEC                                                                               | $863,557        |
-| ALP                                         | Australian Labor Party (Northern Territory) Branch - NT                           | $843,328        |
-| LIB                                         | The Liberal Party of Western Australia Pty Ltd                                    | $817,377        |
-| LIB                                         | LIB - WA                                                                          | $810,375        |
-| LIB                                         | LIB-WA                                                                            | $788,591        |
-| GetUp                                       | GetUp Limited                                                                     | $787,998        |
-| ASXP                                        | Australian Sex Party                                                              | $773,540        |
-| NAT                                         | NAT-FED                                                                           | $772,709        |
-| ALP                                         | ALP NSW                                                                           | $734,596        |
-| GRN                                         | Australian Greens, Victorian Branch                                               | $724,172        |
-| LIB                                         | Forward Brisbane Leadership                                                       | $719,183        |
-| ALP                                         | Progressive Business Association Inc                                              | $695,458        |
-| PUP                                         | PUP - Palmer United Party                                                         | $688,537        |
-| ALP                                         | Australian Labor Party (Tasmanian Branch) - TAS                                   | $676,932        |
-| LIB                                         | LIB-TAS                                                                           | $657,329        |
-| LIB                                         | Higgins 200 Club                                                                  | $656,774        |
-| LIB                                         | ADVANCE AUSTRALIA                                                                 | $650,000        |
-| CLP                                         | Northern Territory Country Liberal Party - NATIONAL                               | $632,078        |
-| LIB                                         | LIB-VIC                                                                           | $631,242        |
-| GRN                                         | Australian Greens (South Australia)                                               | $624,274        |
-| LIB                                         | Liberal Party of Australia (QLD Division)                                         | $611,233        |
-| ALA                                         | Australian Liberty Alliance                                                       | $595,614        |
-| ALP                                         | Progressive Business Association                                                  | $589,326        |
-| CEC                                         | CEC-FED                                                                           | $584,348        |
-| NAT                                         | National Party of Australia - National Secretariat                                | $565,874        |
-| ALP                                         | Australian Labor Party (ACT Branch)                                               | $551,444        |
-| LIB                                         | Liberal Party of Australia, NSW Division (LIB-NSW)                                | $550,000        |
-| ALP                                         | Australian Labor Party (Tasmanian Branch)                                         | $544,029        |
-| ALP                                         | Australian Labor Party (WA Branch)                                                | $535,414        |
-| LIB                                         | Millennium Forum                                                                  | $522,919        |
-| LIB                                         | Lib-FED                                                                           | $510,000        |
-| ALP                                         | ALP-QLD                                                                           | $506,185        |
-| TGA                                         | The Great Australian Party                                                        | $500,000        |
-| LIB                                         | Sir Charles Court Foundation                                                      | $500,000        |
-| ALP                                         | Australian Labor Party (ALP                                                       | $500,000        |
-| NAT                                         | National Party of Australia - NSW                                                 | $481,274        |
-| LIB                                         | Liberal Party of Australia - Tasmanian Division - TAS                             | $474,424        |
-| ALP                                         | ALP-VIC                                                                           | $453,337        |
-| GRN                                         | Queensland Greens                                                                 | $452,035        |
-| LIB                                         | Liberal Party of Australia - ACT Division                                         | $450,488        |
-| NAT                                         | NAT-NSW                                                                           | $444,128        |
-| CLP                                         | Northern Territory Country Liberal Party                                          | $430,784        |
-| LIB                                         | LIB - FED                                                                         | $414,319        |
-| KAP                                         | Katter's Australian Party (KAP)                                                   | $412,282        |
-| KAP                                         | KAP-FED                                                                           | $398,455        |
-| LNP                                         | Liberal National Party                                                            | $388,818        |
-| LIB                                         | Free Enterprise Foundation                                                        | $383,000        |
-| DEM                                         | Australian Democrats - NATIONAL                                                   | $380,763        |
-| LNP                                         | LNP                                                                               | $372,082        |
-| LIB                                         | The Liberal Party of Australia                                                    | $366,151        |
-| LIB                                         | Liberal Party of Australia - ACT Division - ACT                                   | $363,518        |
-| NAT                                         | NAT-WA                                                                            | $360,498        |
-| Warringah Independent                       | Warringah Independent Limited                                                     | $354,800        |
-| GRN                                         | Australian Greens, Tasmanian Branch                                               | $351,684        |
-| LIB                                         | Liberal Party of Aust NSW Division                                                | $344,338        |
-| LIB                                         | Liberal Party of Australia LIB-FED                                                | $332,080        |
-| ALP                                         | Australian Labor Party (SA Branch)                                                | $329,793        |
-| DEM                                         | Australian Democrats SA Division - SA                                             | $326,315        |
-| ALP                                         | ALP-SA                                                                            | $324,729        |
-| LIB                                         | Federal Secretariat - LIB-FED                                                     | $320,000        |
-| ALP                                         | National Secretariat - ALP-FED                                                    | $312,200        |
-| LIB                                         | Liberal Party of Australia / LIB-FED                                              | $308,793        |
-| LIB                                         | Liberal Party of Australia (LIB-FED)                                              | $304,700        |
-| GRN                                         | Australian Greens - TAS                                                           | $304,171        |
-| LIB                                         | LIB - NSW                                                                         | $284,895        |
-| LIB                                         | Liberal Party of Australia - NSW                                                  | $284,127        |
-| Australian Chamber of Commerce and Industry | Australian Chamber of Commerce and Industry                                       | $282,634        |
-| ALP                                         | Emily's List Australia                                                            | $267,459        |
-| GRN                                         | The Greens NSW - NSW                                                              | $267,382        |
-| VOTEFLUX.ORG                                | VOTEFLUX.ORG / Upgrade Democracy!                                                 | $261,729        |
-| AUC                                         | Australian Christians                                                             | $260,303        |
-| LDP                                         | Liberal Democratic Party                                                          | $260,230        |
-| LIB                                         | Liberal Party of Australia LIB                                                    | $258,000        |
-| NAT                                         | National Party of Australia - Victoria - VIC                                      | $257,472        |
-| LIB                                         | Liberal Party of Australia (VIC Division) (paid to Enterprise 500)                | $256,700        |
-| GetUp                                       | GetUp Ltd                                                                         | $251,500        |
-| LIB                                         | Liberal Party of Australia/ LIB                                                   | $250,000        |
-| LIB                                         | Liberal Party (WA) Division Inc LIB-WA                                            | $250,000        |
-| ALP                                         | Australian Labor Party / ALP-FED                                                  | $249,800        |
-| ALP                                         | ALP - NSW                                                                         | $247,559        |
-| LIB                                         | Liberal Party of Australia (ACT Division)                                         | $245,860        |
-| ALP                                         | ALP-WA                                                                            | $245,217        |
-| ALP                                         | ALP FED                                                                           | $238,771        |
-| RPA                                         | Republican Party of Australia - NATIONAL                                          | $237,257        |
-| ALP                                         | ALP NSW Branch                                                                    | $226,490        |
-| AJP                                         | Animal Justice Party                                                              | $224,550        |
-| LIB                                         | Liberal Party of Australia - NSW Division                                         | $218,980        |
-| GRN                                         | GRN-QLD Queensland Greens                                                         | $205,000        |
-| ALP                                         | Australian Council of Trade Unions (ACTU)                                         | $200,000        |
-| LIB                                         | Lib-WA                                                                            | $200,000        |
-| ALP                                         | ALP (Griffith FEC)                                                                | $200,000        |
-| ALP                                         | Australian Labour Party (LAB-FED)                                                 | $200,000        |
-| LIB                                         | Liberal Party (LIB-FED)                                                           | $200,000        |
-| LNP                                         | LNP QLD                                                                           | $197,490        |
-| ASP                                         | Shooters and Fishers Party                                                        | $196,024        |
-| SPP                                         | Australian Stable Population Party                                                | $194,320        |
-| NAT                                         | NAT                                                                               | $194,106        |
-| SPP                                         | #Sustainable Population Party                                                     | $190,150        |
-| GRN                                         | The Greens (WA) Inc - NATIONAL                                                    | $188,950        |
-| LIB                                         | Liberal Party of Australia (TAS Division)                                         | $187,584        |
-| LIB                                         | Liberal Party of Australia - NSW Branch                                           | $185,822        |
-| LIB                                         | Liberal Party of Australia/LIB-FED                                                | $183,550        |
-| LIB                                         | Liberal Party Federal Secretariat - LIB-ACT                                       | $180,000        |
-| LIB                                         | Liberal Party of Australia / LIB                                                  | $177,775        |
-| LIB                                         | Liberal National Party of Queensland LNP-QLD                                      | $176,700        |
-| LIB                                         | Liberal Party of Australia NSW Division                                           | $173,333        |
-| CLP                                         | CLP-NT                                                                            | $172,800        |
-| GRN                                         | Australian Greens - NATIONAL                                                      | $172,682        |
-| Australian Chamber of Commerce and Industry | Campaign for Small Business (Australian Chamber of Commerce and Industry)         | $170,928        |
-| FFP                                         | Family First Party - VIC                                                          | $170,000        |
-| ALP                                         | Australian Labour Party                                                           | $164,594        |
-| AFLP                                        | Australian Fishing and Lifestyle Party                                            | $163,255        |
-| GLT                                         | GLT                                                                               | $160,317        |
-| LIB                                         | Liberal Party of Australia (SA Division) / LIB-SA                                 | $160,000        |
-| ALP                                         | ALP-NT                                                                            | $159,050        |
-| NAT                                         | National Party of Aust - NSW                                                      | $155,310        |
-| CLP                                         | Country Liberal Party (NT)                                                        | $154,900        |
-| CEC                                         | CEC-Fed                                                                           | $154,411        |
-| ALP                                         | ALP- Australian Labor Party                                                       | $152,000        |
-| Brisbane's Future Committee                 | The Brisbane's Future Committee                                                   | $151,500        |
-| LIB                                         | Liberal Party LIB-NSW                                                             | $150,750        |
-| DEM                                         | Australian Democrats, Western Australian Division - WA                            | $150,367        |
-| LIB                                         | Liberal Party of Australia (W.A. Division)                                        | $150,000        |
-| LIB                                         | LIB - Liberal Party of Australia                                                  | $150,000        |
-| LIB                                         | Liberal Party of Australia (Victorian Division) / LIB-VIC                         | $149,341        |
-| GRN                                         | GRN-NSW                                                                           | $148,426        |
-| ALP                                         | ALP - VIC                                                                         | $148,298        |
-| LIB                                         | The 500 Club (VIC)                                                                | $147,407        |
-| ALP                                         | ALP - FED                                                                         | $141,665        |
-| ALP                                         | ALP-TAS                                                                           | $140,842        |
-| ALP                                         | Australian Labor Party - NSW Branch                                               | $140,653        |
-| DEM                                         | Australian Democrats - National Executive                                         | $137,616        |
-| DLP                                         | Democratic Labor Party (DLP) of Australia - NATIONAL                              | $134,000        |
-| ALP                                         | Australian Labor Party Victorian Branch                                           | $132,967        |
-| LIB                                         | The 500 Club (WA)                                                                 | $132,547        |
-| LIB                                         | LIB NSW                                                                           | $131,329        |
-| CCC                                         | Climate Change Coalition                                                          | $130,519        |
-| ALP                                         | Australian Labor Party (TAS Branch)                                               | $129,852        |
-| ACP                                         | Australian Conservatives (Qld)                                                    | $125,000        |
-| NAT                                         | National Party                                                                    | $124,166        |
-| GetUp                                       | Get Up                                                                            | $123,245        |
-| ALP                                         | Australian Labor Party (ALP) / ALP-FED                                            | $122,800        |
-| GRN                                         | The Greens NSW - NATIONAL                                                         | $122,560        |
-| ALP                                         | Progressive Business                                                              | $121,441        |
-| RUA                                         | Rise Up Australia Party                                                           | $121,100        |
-| ON                                          | Pauline Hanson's One Nation                                                       | $119,338        |
-| CDP                                         | Christian Democratic Party (Fred Nile Group) NSW                                  | $117,120        |
-| GRN                                         | Australian Greens, Australian Capital Territory Branch                            | $115,536        |
-| ALP                                         | Australian Labor Party (SA Branch) ALP-SA                                         | $115,126        |
-| LIB                                         | Liberal Party of Australia LIB FED                                                | $114,000        |
-| LIB                                         | Liberal Party of Aust.                                                            | $110,000        |
-| LIB                                         | The Menzies Research Centre Limited                                               | $103,000        |
-| LIB                                         | Liberal Party of Australia (WA Div)                                               | $102,000        |
-| LIB                                         | Liberal National Party/LNP-QLD                                                    | $100,500        |
-| LIB                                         | Advanced Australia                                                                | $100,000        |
-| XEN                                         | (NXT) XEN                                                                         | $100,000        |
-| LIB                                         | LIB- FED                                                                          | $100,000        |
-| XEN                                         | XEN                                                                               | $100,000        |
-| LIB                                         | The Free Enterprise Foundation / LIB                                              | $100,000        |
-| VEP                                         | Voluntary Euthanasia Party                                                        | $100,000        |
-| DLP                                         | DLP-VIC                                                                           | $100,000        |
-| LIB                                         | Liberal Party of Australia (LIB-ACT)                                              | $100,000        |
-| LIB                                         | LIB-ACT- Federal Secretariat                                                      | $100,000        |
-| LPA                                         | LPA-NSW                                                                           | $100,000        |
-| ALP                                         | ALP NSW (Federal Campaign)                                                        | $100,000        |
-| GRN                                         | Australian Greens Victorian Branch                                                | $100,000        |
-| ALP                                         | ALP-FED (Hughes)                                                                  | $100,000        |
-| AEQ                                         | Australian Equality Party (Marriage)                                              | $99,999         |
-| ALP                                         | ALP National Secretariat - ALP                                                    | $99,716         |
-| GRN                                         | Queensland Greens - NATIONAL                                                      | $98,711         |
-| ON                                          | Pauline Hansons One Nation QLD Division                                           | $98,175         |
-| DLP                                         | Democratic Labour Party - Victorian Branch                                        | $98,130         |
-| CDP                                         | Christian Democratic Party (Fred Nile Group) - WA                                 | $96,200         |
-| ALP                                         | SA Progressive Business Incorporated                                              | $95,238         |
-| LNP                                         | LIBERAL NATIONAL PARTY                                                            | $93,283         |
-| LIB                                         | Liberal Party of Australia (VIC Division) (paid to Enterprise Victoria)           | $92,000         |
-| GetUp                                       | GetUp                                                                             | $91,720         |
-| LIB                                         | Liberal Party                                                                     | $90,829         |
-| ACP                                         | Australian Conservatives (Vic)                                                    | $90,826         |
-| Warringah Independent                       | Warringah Independent Ltd                                                         | $90,000         |
-| LIB                                         | Liberal Democratic Party (LDP)                                                    | $90,000         |
-| LIB                                         | Liberal Party of Australia (SA) LIB-SA                                            | $88,127         |
-| LIB                                         | Lib-Fed                                                                           | $85,475         |
-| LIB                                         | Liberal Party of Australia - VIC Branch                                           | $84,592         |
-| LIB                                         | Liberal Party of Australia LIB-VIC                                                | $82,663         |
-| ALP                                         | Australian Labor Party - NSW                                                      | $80,252         |
-| GetUp                                       | Getup Ltd                                                                         | $80,000         |
-| LNP                                         | LIBERAL NATIONAL PARTY (LNP)                                                      | $80,000         |
-| LIB                                         | Liberal Party of Australia - LIB VIC                                              | $80,000         |
-| ALP                                         | Australia Labor Party (ALP)                                                       | $80,000         |
-| LIB                                         | Liberal Party of Australia (LIB)                                                  | $80,000         |
-| ACP                                         | Australian Conservatives                                                          | $77,600         |
-| LIB                                         | Liberal Party of Australia (WA Div) Inc - LIB-WA                                  | $76,000         |
-| ALP                                         | Australian Labor Party (ALP) / ALP                                                | $75,900         |
-| JLN                                         | Jacqui Lambie Network                                                             | $75,700         |
-| LIB                                         | Advance Aus Limited                                                               | $75,000         |
-| ACP                                         | Australian Conservatives (NSW)                                                    | $75,000         |
-| ARF                                         | Australian Recreational Fishers Party                                             | $75,000         |
-| KAP                                         | KATTER'S AUSTRALIAN PARTY / KAP                                                   | $75,000         |
-| HPA                                         | Hope Party Australia                                                              | $74,898         |
-| LIB                                         | Liberal Party of Australia - NSW - LIB NSW                                        | $74,000         |
-| SAL                                         | Socialist Alliance                                                                | $73,700         |
-| CLR                                         | Country Labor Party                                                               | $73,664         |
-| ALP                                         | McKell Foundation Inc                                                             | $73,333         |
-| ALP                                         | Australian Labor Party - VIC Branch                                               | $73,042         |
-| ALP                                         | Australian Labor Party - ALP-FED                                                  | $72,920         |
-| LIB                                         | Liberal Party of Australia NSW                                                    | $71,568         |
-| GRN                                         | The Australian Greens - Victoria - NATIONAL                                       | $70,573         |
-| LIB                                         | Liberal Party of Australia (NSW) Division                                         | $70,272         |
-| LIB                                         | Liberal Party of Australia/LIB-NSW                                                | $70,050         |
-| LIB                                         | LIB FED                                                                           | $70,000         |
-| LIB                                         | Liberal Party of Australia LIB - FED                                              | $70,000         |
-| ALP                                         | ALP NATIONAL SECRETARIAT ALP-FED                                                  | $69,500         |
-| LIB                                         | Liberal Party of Australia (SA Division) LIB-SA                                   | $69,471         |
-| ALP                                         | ALP-ACT - National Secretariat                                                    | $69,000         |
-| ASP                                         | Shooters, Fishers and Farmers Party                                               | $68,700         |
-| LIB                                         | Liberal Party of Austtralia, NSW Division LIB-NSW                                 | $68,210         |
-| ALP                                         | Australian Labor Party (Queensland)                                               | $68,144         |
-| CDP                                         | Christian Democratic Party (Fred Nile Group) - NATIONAL                           | $67,721         |
-| ON                                          | Pauline Hanson's One Nation QLD Division                                          | $67,720         |
-| Warringah Independent                       | Warringah Independents                                                            | $67,000         |
-| ALP                                         | Australian Labor Party National Secretariat                                       | $66,000         |
-| LNP                                         | Liberal National Party of Queensland / LNP-QLD                                    | $65,970         |
-| ALP                                         | ALP-NAT                                                                           | $65,735         |
-| LIB                                         | 250 Club Limited                                                                  | $65,296         |
-| Western Australia                           | WESTERN AUSTRALIA PARTY                                                           | $65,000         |
-| ALP                                         | ALP -NSW                                                                          | $65,000         |
-| LNP                                         | Liberal National Party (LNP-QLD)                                                  | $65,000         |
-| LIB                                         | Liberal Party of Australia - VIC                                                  | $65,000         |
-| ALP                                         | ALP-FED Federal Labor Business Forum                                              | $64,800         |
-| LNP                                         | LNP - QLD                                                                         | $64,791         |
-| LIB                                         | Liberal Party of Australia (Victorian Division) - LIB-VIC                         | $64,640         |
-| LIB                                         | Liberal Party NSW Division                                                        | $64,571         |
-| ALP                                         | Australian Labor Party - SA Branch                                                | $64,566         |
-| ALP                                         | Australian Labor Party - VIC                                                      | $62,830         |
-| LIB                                         | LIBERAL PARTY OF AUSTRALIA                                                        | $62,000         |
-| LNP                                         | LNP Queensland                                                                    | $61,200         |
-| ALP                                         | ALP-WA Australian Labor Party (Western Australian Branch)                         | $61,000         |
-| LIB                                         | Liberal Party of Australia (Tas Div)                                              | $60,959         |
-| LIB                                         | LIB - VIC                                                                         | $60,667         |
-| LIB                                         | LIB-ACT                                                                           | $60,118         |
-| LIB                                         | Liberal Party of Aust LIB-FED                                                     | $60,000         |
-| AUC                                         | Australian Christians - ACH                                                       | $60,000         |
-| SPP                                         | SPP-FED                                                                           | $60,000         |
-| LIB                                         | Canberra Liberals (LIB-ACT)                                                       | $60,000         |
-| LIB                                         | Liberal Foundation Inc                                                            | $60,000         |
-| LIB                                         | Liberal Party of Australia SA LIB-SA                                              | $59,202         |
-| CEC                                         | CEC Australia (Services) Pty Ltd                                                  | $58,950         |
-| ALP                                         | Australian Labor Party SA ALP-SA                                                  | $58,784         |
-| ALP                                         | Australian Labor Party (ALP-FED)                                                  | $57,491         |
-| Warringah Independent                       | Warringah Independents Pty Ltd                                                    | $57,000         |
-| Warringah Independent                       | warringah independent pty ltd                                                     | $57,000         |
-| LIB                                         | Liberal Party of Aust Lib - Fed                                                   | $57,000         |
-| CDP                                         | Christian Democratic Party - WA                                                   | $57,000         |
-| ALP                                         | ALP National Secretariat/ALP-FED                                                  | $56,700         |
-| ALP                                         | ALP - National Secretariat (ALP-FED)                                              | $56,158         |
-| ALP                                         | ALP National Secretariat - ALP-FED                                                | $56,000         |
-| CDP                                         | Christian Democratic Party (Fred Nile Group) WA Branch                            | $55,500         |
-| LIB                                         | Liberal Party of Australia (LIB/FED)                                              | $55,052         |
-| GRN                                         | Australian Greens - ACT                                                           | $55,024         |
-| LIB                                         | Liberal Party of Australia Lib-Fed                                                | $55,000         |
-| ALP                                         | Australian Labor Party - QLD /ALP-QLD                                             | $54,250         |
-| SPP                                         | SPP                                                                               | $54,000         |
-| ALP                                         | ALP - National Secretariat Business Forum                                         | $54,000         |
-| ALP                                         | Australian Labor Party (NT Branch)                                                | $54,000         |
-| ALP                                         | ALP QLD                                                                           | $53,740         |
-| ALP                                         | ALP-National Secretariat                                                          | $53,525         |
-| LIB                                         | Liberal Party of Australia/LIB-TAS                                                | $53,270         |
-| LIB                                         | LIB-VIC Liberal Party of Australia (Vic Division)                                 | $53,115         |
-| ALP                                         | Australian Labor Party                                                            | $52,900         |
-| LIB                                         | LIB Liberal Party of Australia                                                    | $52,250         |
-| LIB                                         | Liberal Party of Aust NSW                                                         | $52,160         |
-| GetUp                                       | GETUP LTD                                                                         | $52,000         |
-| LIB                                         | Liberal Party of Australia, NSW Division / LIB-NSW                                | $51,677         |
-| LIB                                         | LIB - SA                                                                          | $51,119         |
-| LDP                                         | Liberal Democratic Party (QLD Branch)                                             | $50,990         |
-| ALP                                         | Australian Labor Party (QLD Branch)                                               | $50,400         |
-| ALP                                         | Australian Labor Party (State of Queensland) / ALP-QLD                            | $50,268         |
-| NAT                                         | NAT-WA National Party of Australia (WA) Inc                                       | $50,250         |
-| RPA                                         | Republican Party of Australia                                                     | $50,200         |
-| LIB                                         | Liberal Party of Australia (SA Branch)                                            | $50,175         |
-| LIB                                         | Advance Australia Ltd                                                             | $50,000         |
-| LIB                                         | LIB Party of Australia (QLD Division)                                             | $50,000         |
-| GetUp                                       | Get Up Ltd                                                                        | $50,000         |
-| LIB                                         | Liberal Party of Australia (wa Division) Inc                                      | $50,000         |
-| LNP                                         | Mr Bruce McIver, LNP Federal Campaign                                             | $50,000         |
-| FNPP                                        | Australia's First Nations Political Party (FNP)                                   | $50,000         |
-| LIB                                         | Liberal Party of Australia (Victorian Division) LIB-VIC                           | $50,000         |
-| NAT                                         | NSW Nationals - NAT-NSW                                                           | $50,000         |
-| LIB                                         | Liberal Party of Australia - Brian Loughnane                                      | $50,000         |
-| ALP                                         | ALP - Macquarie (Susan Templeman)(ALP-NSW)                                        | $50,000         |
-| LIB                                         | Liberal Party of Australia NSW Division (LIB-NSW)                                 | $50,000         |
-| NAT                                         | National (NSW)                                                                    | $50,000         |
-| NAT                                         | Nationals - NAT-FED                                                               | $50,000         |
-| LIB                                         | The Liberal Party of Australia (WA Division)                                      | $50,000         |
-| LIB                                         | Liberal Party of Aust - LIB-FED                                                   | $50,000         |
-| CLP                                         | CLP NT                                                                            | $50,000         |
-| ALP                                         | ALP NT                                                                            | $50,000         |
-| ALP                                         | Labour Movement Work Experience Program                                           | $49,857         |
-| GRN                                         | Australian Greens - Victoria                                                      | $49,685         |
-| ALP                                         | Progressive Business Association - VIC Branch                                     | $49,332         |
-| LIB                                         | Liberal Party of Australia VIC                                                    | $49,118         |
-| NAT                                         | National Party of Australia - Victoria (NAT-VIC)                                  | $48,900         |
-| ALP                                         | ALP Progressive Business (SA)                                                     | $48,272         |
-| ON                                          | One Nation Queensland Division                                                    | $48,000         |
-| ALP                                         | Progressive Business Association ALP-VIC                                          | $47,390         |
-| ALP                                         | Australian Labor Party (South Australian Branch) ALP-SA                           | $46,774         |
-| LIB                                         | LIB-VIC Liberal Party of Australia (Victoria Division)                            | $46,765         |
-| LIB                                         | Liberal Party of Aust, NSW Division                                               | $46,070         |
-| CDP                                         | Christian Democratic Party (Fred Nile Group) Natio                                | $45,587         |
-| ALP                                         | Australian Labor Party ALP-FED                                                    | $45,296         |
-| CLP                                         | CLPNT                                                                             | $45,000         |
-| LIB                                         | Liberal Party Manly SEC                                                           | $45,000         |
-| LIB                                         | Liberal Party of Australia / LIB-WA                                               | $45,000         |
-| LIB                                         | Liberal Party of WA                                                               | $44,975         |
-| ON                                          | One Nation Western Australia - WA                                                 | $44,624         |
-| LIB                                         | Liberal Party of Australia Federal Forum/LIB-NSW                                  | $44,000         |
-| NAT                                         | National Party of NSW                                                             | $44,000         |
-| LIB                                         | LIberal Party of Australia (WA)                                                   | $43,950         |
-| ALP                                         | Australian Labor Party/ALP-FED                                                    | $43,000         |
-| LIB                                         | 250 Club Ltd                                                                      | $42,900         |
-| Independent                                 | Independents For Climate Action Now                                               | $42,000         |
-| LIB                                         | Menzies 200 Club                                                                  | $41,785         |
-| LIB                                         | Liberal Party of Australia (Vic Division)                                         | $41,500         |
-| UNI                                         | Unity - Say NoTo Hanson                                                           | $41,000         |
-| LIB                                         | Liberal Party of Australia (LIB)                                                  | $40,893         |
-| LIB                                         | Liberal Party of Australia - SA LIB-SA                                            | $40,672         |
-| ALP                                         | ALP-Federal                                                                       | $40,450         |
-| NAT                                         | NPA Nominees Pty Ltd                                                              | $40,116         |
-| LIB                                         | Liberal Party of NSW                                                              | $40,067         |
-| GetUp                                       | GET UP LIMITED                                                                    | $40,000         |
-| SPP                                         | SUSTAINABLE AUSTRALIA - STOP OVERDEVELOPMENT. STOP CORRUPTION.                    | $40,000         |
-| LNP                                         | LNP - Whitsunday                                                                  | $40,000         |
-| LIB                                         | LPA - NSW (Federal Campaign)                                                      | $40,000         |
-| LIB                                         | The Liberal Party of Australia / LIB-FED                                          | $40,000         |
-| ALP                                         | ALP Federal Secretariat                                                           | $40,000         |
-| CLP                                         | CLP                                                                               | $40,000         |
-| ALP                                         | Australian Labor Party - SA ALP-SA                                                | $39,795         |
-| Australian Chamber of Commerce and Industry | Australia Chamber of Commerce and Industry                                        | $39,600         |
-| NAT                                         | NAT - NSW                                                                         | $39,280         |
-| NCO                                         | New Country Party - NATIONAL                                                      | $39,279         |
-| LIB                                         | Enterprise Victoria (LIB-VIC)                                                     | $39,100         |
-| LNP                                         | Liberal National Party of Queensland/LNP-QLD                                      | $39,008         |
-| LIB                                         | Libs-NSW                                                                          | $38,750         |
-| LIB                                         | Liberal Party of Australia LIB-NSW                                                | $38,727         |
-| LIB                                         | Liberal Party of Australia - TAS                                                  | $38,550         |
-| LIB                                         | Liberal Party of Australia - LIB-TAS                                              | $38,200         |
-| ALP                                         | Australia Labor Party (State of Queensland) / ALP-QLD                             | $38,000         |
-| LNP                                         | Liberal National Party of Qld                                                     | $38,000         |
-| ALP                                         | ALP - WA                                                                          | $37,879         |
-| Warringah Independant                       | Warringah Independant Limited                                                     | $37,631         |
-| ALP                                         | ALP - Fed                                                                         | $37,600         |
-| LIB                                         | Liberal Party of Australia (SA Div)                                               | $37,272         |
-| LIB                                         | Liberal Party NSW Federal Campaign Account - LIB-NSW                              | $37,100         |
-| ALP                                         | Aust Labor Party (SA Branch)/ALP-SA                                               | $37,060         |
-| HMP                                         | Help End Marijuana Prohibition (HEMP) Party                                       | $37,000         |
-| DEM                                         | Australian Democrats Victorian Division - VIC                                     | $36,993         |
-| LIB                                         | LIB-VIC (Enterprise 500)                                                          | $36,500         |
-| ALP                                         | Australian Labour Party (VIC Branch)                                              | $36,372         |
-| ALP                                         | Australian Labor Party (ALP) ALP-FED                                              | $36,200         |
-| GRN                                         | Greens NSW                                                                        | $35,880         |
-| ALP                                         | ALP-NSW Australian Labor Party (NSW Branch)                                       | $35,700         |
-| ALP                                         | Australian Labor Party / ALP                                                      | $35,600         |
-| LIB                                         | Liberal Party of Aust LIB-NSW                                                     | $35,000         |
-| LIB                                         | Liberal Party of Aust Lib - NSW                                                   | $35,000         |
-| ALP                                         | Australian Labor Party of Qld                                                     | $35,000         |
-| UNI                                         | Unity - Say No To Hanson - NATIONAL                                               | $34,925         |
-| ALP                                         | Australia Labor Party (ALP)                                                       | $34,500         |
-| ALP                                         | ALP-FED Australian Labor Party (ALP)                                              | $34,500         |
-| LIB                                         | Liberal Party of Australia/LIB                                                    | $34,288         |
-| ALP                                         | Australian Labor Party (ALP) - National Secretariat                               | $33,800         |
-| ALP                                         | Australian Labor Party (Western Australia Branch)                                 | $33,750         |
-| DEM                                         | Australian Democrats - SA Division Inc                                            | $33,722         |
-| LNP                                         | Liberal National Party QLD                                                        | $33,686         |
-| LIB                                         | LIB - Vic                                                                         | $33,604         |
-| LIB                                         | Liberal Party of Australia, NSW Division / LIB NSW                                | $33,326         |
-| LIB                                         | North Sydney Forum - LIB-NSW                                                      | $33,000         |
-| LNP                                         | LNP - FDC                                                                         | $33,000         |
-| ALP                                         | Australian Labor Party (Victorian Branch) / ALP-VIC                               | $32,200         |
-| LIB                                         | Lib-Federal                                                                       | $32,075         |
-| LNP                                         | LNP/LNP-QLD                                                                       | $32,010         |
-| GRN                                         | GRN-WA                                                                            | $32,000         |
-| DLP                                         | Democratic Labor Party (DLP) - Victorian Branch                                   | $31,267         |
-| ALP                                         | Australian Labor Party (N.S.W Branch) ALP-NSW                                     | $31,100         |
-| CLP                                         | COUNTRY LIBERAL PARTY (NT)                                                        | $31,000         |
-| ALP                                         | ALP National Secretariat/ALP - FED                                                | $31,000         |
-| NAT                                         | National Party of Australia Federal Campaign - NAT-NSW                            | $30,700         |
-| LIB                                         | Liberal Party - LIB - NSW                                                         | $30,480         |
-| ALP                                         | ALP NSW BANKS CAMPAIGN                                                            | $30,000         |
-| ALP                                         | ALP-SA Australian Labor Party (South Australian Branch)                           | $30,000         |
-| ACP                                         | ACP-VIC                                                                           | $30,000         |
-| ALP                                         | Australian Labor Party NSW Branch Watson Federal Campaign A/C ALP-NSW             | $30,000         |
-| NAT                                         | NATIONAL PARTY OF AUSTRALIA (NAT - FED)                                           | $30,000         |
-| LIB                                         | LIB (Enterprise 500 Victoria)                                                     | $30,000         |
-| CCA                                         | Country Alliance                                                                  | $30,000         |
-| LIB                                         | The Liberal Party of Australia Victorian Division                                 | $30,000         |
-| ALP                                         | ALP QLD - Dawson (Mike Brunker)                                                   | $30,000         |
-| ALP                                         | ALP QLD - Flynn (Chris Trevor)                                                    | $30,000         |
-| LIB                                         | Lib - SA                                                                          | $30,000         |
-| ALP                                         | ALP-FED (Cook)                                                                    | $30,000         |
-| LNP                                         | Altum LNP-QLD                                                                     | $30,000         |
-| ALP                                         | Labor Business Dialogue                                                           | $30,000         |
-| LIB                                         | LIB TAS                                                                           | $29,761         |
-| LIB                                         | LIB-NSW - Millennium Forum of New South Wales Federal Account                     | $29,600         |
-| LIB                                         | Lib - NSW                                                                         | $29,465         |
-| ALP                                         | Australian Labor Party - ALP - FED                                                | $29,266         |
-| LIB                                         | LIB - VIC (Higgins 200 Club)                                                      | $28,700         |
-| ALP                                         | ALP - TAS                                                                         | $28,540         |
-| LNP                                         | Liberal National Party LNP-QLD                                                    | $28,034         |
-| GRN                                         | GRN-VIC                                                                           | $28,000         |
-| DEM                                         | Australian Democrats Queensland Division                                          | $27,600         |
-| LIB                                         | Australian Business Network (LIB-FED)                                             | $27,500         |
-| ALP                                         | Federal Labor Business Forum (ALP-NAT)                                            | $27,500         |
-| LIB                                         | LIB (Higgins 200 Club)                                                            | $27,500         |
-| LIB                                         | LIB-VIC (Higgins 200 Club)                                                        | $27,500         |
-| LIB                                         | Lib-Vic (Higgins 200 Club)                                                        | $27,500         |
-| NAT                                         | Nationa Party of Australia/NAT-FED                                                | $27,500         |
-| LIB                                         | Millenium Forum - NSW-EFT                                                         | $27,500         |
-| ALP                                         | ALP Progressive Business (VIC)                                                    | $27,398         |
-| LIB                                         | Liberal Party of Australia, NSW Division - LIB-NSW                                | $27,380         |
-| LIB                                         | Secondment - LIB-FED                                                              | $27,379         |
-| LIB                                         | Liberal Party of Australia (W.A Division) Inc                                     | $27,370         |
-| NAT                                         | National Party of Australia (WA) Inc (NAT-WA)                                     | $27,200         |
-| HAR                                         | Tasmanian Independent Senator Brian Harradine Grou                                | $27,000         |
-| CDP                                         | Christian Democratic Party (Fred Nile Group) - NSW                                | $26,928         |
-| ON                                          | Pauline Hanson's One Nation - QLD                                                 | $26,875         |
-| LIB                                         | Liberal Party (W.A. Division) Inc. / LIB-WA                                       | $26,809         |
-| LIB                                         | The Pinnacle Club - Liberal Party of Australia (Victorian Division)               | $26,700         |
-| LDP                                         | Liberal Democratic Party (Victoria Branch)                                        | $26,670         |
-| LIB                                         | Liberal Party of Australia LIB - TAS                                              | $26,563         |
-| LIB                                         | Liberal Party of Australia ACT                                                    | $26,548         |
-| LIB                                         | LIBERAL PARTY - FEDERAL - LIB-FED                                                 | $26,500         |
-| NAT                                         | National Party of Australia / NAT-FED                                             | $26,500         |
-| LIB                                         | Liberal Party of Australia - VIC Division                                         | $26,200         |
-| LIB                                         | Liberal Party of Victoria                                                         | $26,181         |
-| ALP                                         | Australian Labor Party (Victorian Branch) ALP-VIC                                 | $26,167         |
-| LIB                                         | Liberal Party LIB-ACT                                                             | $26,000         |
-| LIB                                         | The Liberal Party of Australia (Victorian Division) / LIB-VIC                     | $26,000         |
-| ALP                                         | Australian Labor Party (QLD)                                                      | $26,000         |
-| LIB                                         | 500 Club of New South Wales Inc                                                   | $25,992         |
-| AAHP                                        | Australian Affordable Housing Party                                               | $25,919         |
-| LIB                                         | Liberal Party of Australia LIB NSW                                                | $25,500         |
-| LIB                                         | LIB-VIC Liberal Party of Australia (Victorian Division)                           | $25,330         |
-| Warringah Independent                       | Warringah Independent Limited                                                     | $25,250         |
-| ALP                                         | Australian Labor Party (ALP) - ALP                                                | $25,250         |
-| LIB                                         | Liberal Party of Australia - Tasmanian Division / LIB-TAS                         | $25,200         |
-| KP Independents                             | KP Independents Limited                                                           | $25,000         |
-| LIB                                         | LIB Party of Australia (NSW Division)                                             | $25,000         |
-| LIB                                         | LIB-WA Liberal Party (WA Division Inc)                                            | $25,000         |
-| CLP                                         | The Free Enterprise Foundation - CLP-NT - Country Liberals                        | $25,000         |
-| ALP                                         | ALP-VIC - Chisholm FEA                                                            | $25,000         |
-| LIB                                         | Liberal Party of Australia, NSW Division, Mitchell FEC                            | $25,000         |
-| LIB                                         | Liberal Party (Vic Div.)                                                          | $25,000         |
-| LIB                                         | Liberal Party of Australia - Tasmania                                             | $25,000         |
-| LIB                                         | Liberal Party of Australia (WA Division) Inc/LIB-WA                               | $25,000         |
-| LIB                                         | Liberal Party of Australia, NSW Division (Federal account)                        | $25,000         |
-| LIB                                         | Liberal - Curtin Liberal Federal Campaign (WA)                                    | $25,000         |
-| LNP                                         | LNP QUEENSLAND                                                                    | $25,000         |
-| LNP                                         | Liberal National Party of Queensland (Lord Mayor Community Trust)                 | $25,000         |
-| AFLP                                        | AFLP. Aust Fishing & Lifestyle Party                                              | $25,000         |
-| ALP                                         | ALP - Business Forum ALP Federal                                                  | $25,000         |
-| LIB                                         | Liberal Party (WA Division) Inc./LIB-WA                                           | $25,000         |
-| LIB                                         | Enterprise 500 Victoria                                                           | $25,000         |
-| LIB                                         | Menzies Research Centre                                                           | $25,000         |
-| LIB                                         | Warringah FEC                                                                     | $25,000         |
-| LIB                                         | Team 200 Club (assoc with Liberal VIC)                                            | $25,000         |
-| LIB                                         | The Liberal Party of Australia (SA Division)                                      | $25,000         |
-| LIB                                         | Federal Liberal Party                                                             | $25,000         |
-| ALP                                         | ALP - National Secretariat                                                        | $25,000         |
-| LIB                                         | Liberal Party Warringah FEC                                                       | $25,000         |
-| ALP                                         | The Australian Labor Party (Victorian Branch)                                     | $25,000         |
-| LIB                                         | Menzies Research Centre Ltd                                                       | $25,000         |
-| LIB                                         | Free Enterprise Foundation LIB-FED                                                | $25,000         |
-| The Leaders' Forum of Western Australia     | The Leaders' Forum of Western Australia                                           | $25,000         |
-| LIB                                         | Lib - WA                                                                          | $25,000         |
-| UNP                                         | UNP                                                                               | $24,600         |
-| ALP                                         | Australian Labor Party (Northern Territory Branch)                                | $24,595         |
-| ALP                                         | Progressive Business Association / ALP-VIC                                        | $24,469         |
-| ALP                                         | Australian Labor Party - ALP                                                      | $24,460         |
-| GRN                                         | Australian Greens - SA                                                            | $24,450         |
-| LNP                                         | Liberal National Party (LNP)                                                      | $24,000         |
-| LIB                                         | North Sydney Forum/LIB-FED                                                        | $24,000         |
-| LNP                                         | (LNP) Lord Mayors 'Go Forward'                                                    | $24,000         |
-| LNP                                         | LNP/BCC Office Space                                                              | $24,000         |
-| ALP                                         | Progressive Business Association/ALP-VIC                                          | $23,600         |
-| ALP                                         | ALP - Australian Labor Party                                                      | $23,100         |
-| LIB                                         | The 500 Club (LIB-WA)                                                             | $23,000         |
-| ALP                                         | Blacktown                                                                         | $22,871         |
-| LIB                                         | Liberal Party of Australia - NSW Division (LIB-NSW)                               | $22,795         |
-| ALP                                         | Australian Labor Party - Federal Business Forum                                   | $22,727         |
-| LIB                                         | Liberal Party of Australia, NSW Divison / LIB-NSW                                 | $22,545         |
-| LIB                                         | LIB-VIC (Enterprise 500 Victoria)                                                 | $22,500         |
-| LIB                                         | Liberal Party LIB                                                                 | $22,500         |
-| LNP                                         | Liberal National Party of Queensland/ LNP-QLD                                     | $22,500         |
-| ALP                                         | Australian Labor Party (Federal Branch)                                           | $22,500         |
-| NAT                                         | Nationals (WA)                                                                    | $22,331         |
-| LIB                                         | Millenium Forum                                                                   | $22,310         |
-| LIB                                         | Liberal Party of Tasmania - Tasmanian Division / LIB-TAS                          | $22,200         |
-| Peninsular Independent                      | Peninsular Independent Ltd                                                        | $22,000         |
-| ALP                                         | ALP-Fed                                                                           | $22,000         |
-| NAT                                         | John McEwen House Pty Ltd                                                         | $22,000         |
-| LIB                                         | LIB - Menzies Research Centre                                                     | $22,000         |
-| LIB                                         | Liberal Party of Australia - LIB-NSW (Federal Account)                            | $22,000         |
-| ALP                                         | Australian Labor Party (NSW) Branch                                               | $22,000         |
-| ALP                                         | Australian Labor Party NSW Branch Business Member                                 | $22,000         |
-| LIB                                         | Liberal Party of Australia (WA Division)                                          | $21,895         |
-| NAT                                         | National Party NSW                                                                | $21,745         |
-| LIB                                         | Liberal Party Avalon                                                              | $21,680         |
-| ALP                                         | ALP-VIC Progressive Business                                                      | $21,670         |
-| ALP                                         | Australian Labor Party Queensland                                                 | $21,500         |
-| GLT                                         | Glenn Lazarus Team                                                                | $21,220         |
-| ALP                                         | Progressive Business Association - SA Branch                                      | $21,185         |
-| GRN                                         | Tasmanian Greens - NATIONAL                                                       | $21,107         |
-| ASP                                         | Shooters and Fishers Party Inc.                                                   | $21,050         |
-| ALP                                         | ALP-Queensland                                                                    | $21,000         |
-| ALP                                         | Australian Labor Party NSW Branch                                                 | $21,000         |
-| ON                                          | Pauline Hanson's One Nation - NATIONAL                                            | $20,990         |
-| ALP                                         | Australian Labor Party (SA Branch) ALP-SA                                         | $20,780         |
-| GRN                                         | The ACT Greens                                                                    | $20,729         |
-|                                             | One Nation Queensland Division - QLD                                              | $20,650         |
-|                                             | Sustainable Australia Party - Stop Overdevelopment / Corruption                   | $20,500         |
-|                                             | NT CLP                                                                            | $20,500         |
-|                                             | Liberal Party NSW                                                                 | $20,325         |
-|                                             | Liberal Party of Australia (Federal Office)                                       | $20,320         |
-|                                             | ALP-VIC Progressive Business Association                                          | $20,150         |
-|                                             | LIB-WA Liberal Party (W.A. Division) Inc                                          | $20,000         |
-|                                             | getup                                                                             | $20,000         |
-|                                             | ALP-VIC (Hotham)                                                                  | $20,000         |
-|                                             | Cherish Life Queensland Inc                                                       | $20,000         |
-|                                             | ALP Eden-Monaro Federal Campaign Account/ALP-NSW                                  | $20,000         |
-|                                             | LIBERAL PARTY LIB-ACT                                                             | $20,000         |
-|                                             | The Australian Greens - Victoria / GRN-VIC                                        | $20,000         |
-|                                             | Australian Labor Party (Victorian Branch) (paid to ALP Isaacs)                    | $20,000         |
-|                                             | LIB-FED Liberal National Party                                                    | $20,000         |
-|                                             | Australian Greens GRN                                                             | $20,000         |
-|                                             | Australian Fishing & Lifestyle Party                                              | $20,000         |
-|                                             | LPA (WA Division) - LIB-WA                                                        | $20,000         |
-|                                             | ALP (NSW Branch) McMahon FCA - ALP-NSW                                            | $20,000         |
-|                                             | Liberal Party of Australia NSW Branch LIB-NSW                                     | $20,000         |
-|                                             | LIB/Liberal Party of Australia                                                    | $20,000         |
-|                                             | Liberal Party NSW Reid Federal Campaign - LIB-NSW                                 | $20,000         |
-|                                             | Liberal National Party / LNP-QLD                                                  | $20,000         |
-|                                             | LIB / Liberal Party of Australia                                                  | $20,000         |
-|                                             | NSW GREENS                                                                        | $20,000         |
-|                                             | ALP - Chifley Research Centre                                                     | $20,000         |
-|                                             | Lib                                                                               | $20,000         |
-|                                             | ALP-FED/Chifley Research Centre                                                   | $20,000         |
-|                                             | LIB-FED/Menzies Research Centre                                                   | $20,000         |
-|                                             | Forward Brisbane Leadership (LNP QLD)                                             | $20,000         |
-|                                             | Dawn Fardell MP - Liberal Party                                                   | $20,000         |
-|                                             | ALP NSW Division                                                                  | $20,000         |
-|                                             | ALP - Charlton (Greg Combet)(ALP-NSW)                                             | $20,000         |
-|                                             | ALP Melbourne (Cath Bowtell)(ALP-VIC)                                             | $20,000         |
-|                                             | ALP-QLD - Dawson (Mike Brunker)                                                   | $20,000         |
-|                                             | ALP WA -Canning (Alannah McTiernan)                                               | $20,000         |
-|                                             | GRN - ACT                                                                         | $20,000         |
-|                                             | ALP-NSW (Rockdale ALP Campaign)                                                   | $20,000         |
-|                                             | Liberal Party Wannon (LIB-VIC)                                                    | $20,000         |
-|                                             | National Party Lowan Electorate (NAT-VIC)                                         | $20,000         |
-|                                             | Millennium Forum - Liberal Party of Australia NSW Division                        | $20,000         |
-|                                             | Liberal Party of Australia - 2010 Election Campaign                               | $20,000         |
-|                                             | Australian Labor Party - 2010 Election Campaign                                   | $20,000         |
-|                                             | The Nationals (Federal) NAT-FED                                                   | $20,000         |
-|                                             | Lib- SA                                                                           | $20,000         |
-|                                             | Australian Labor Party QLD                                                        | $20,000         |
-|                                             | Mark Dreyfus QC MP ALP-ISAACS                                                     | $20,000         |
-|                                             | Lilley Campaign ALP QLD                                                           | $20,000         |
-|                                             | Liberal Party of Aust - TAS                                                       | $20,000         |
-|                                             | Menzies Research Centre LIB-FED                                                   | $20,000         |
-|                                             | Liberal Party of Australia LIB - VIC                                              | $20,000         |
-|                                             | The Liberal Party of Australia - Federal Secretariat                              | $20,000         |
-|                                             | NT Country Liberal Party                                                          | $20,000         |
-|                                             | Australian Labor Party NT                                                         | $20,000         |
-|                                             | Australian Democrats - NSW Division                                               | $20,000         |
-|                                             | Citizens Electoral Council Australia (NSW Division) - NSW                         | $19,975         |
-|                                             | ALP-SA Australian Labor Party (SA Branch)                                         | $19,845         |
-|                                             | Australian Democrats NSW Division - NSW                                           | $19,842         |
-|                                             | ALP - SA                                                                          | $19,800         |
-|                                             | ALP-FED ALP National Secretariat                                                  | $19,800         |
-|                                             | Liberal Party of Australia, Tasmanian Division                                    | $19,250         |
-|                                             | LIB-NSW - Ray King Fundraiser                                                     | $19,200         |
-|                                             | Australian Labour Party (Federal Branch)                                          | $19,149         |
-|                                             | ALP VIC Branch                                                                    | $19,006         |
-|                                             | Get Up Australia                                                                  | $18,955         |
-|                                             | Tasmanian Greens                                                                  | $18,753         |
-|                                             | LIB - TAS                                                                         | $18,700         |
-|                                             | LPA Tasmania - LIB-TAS                                                            | $18,300         |
-|                                             | Liberal Party of Australia - LIB                                                  | $18,255         |
-|                                             | National Party NAT-FED                                                            | $18,000         |
-|                                             | LIBERAL PARTY OF AUSTRALIA/LIB-FED                                                | $18,000         |
-|                                             | Australian Greens, Australian Capital Territory Branch (GRN-ACT)                  | $18,000         |
-|                                             | Liberal Party of Australia - SA Branch                                            | $17,797         |
-|                                             | ALP (QLD)                                                                         | $17,750         |
-|                                             | Getup                                                                             | $17,703         |
-|                                             | Progressive Business Association (ALP VIC)                                        | $17,640         |
-|                                             | GRN-QLD                                                                           | $17,590         |
-|                                             | LIB-NSW Liberal Party of Australia (NSW Division)                                 | $17,500         |
-|                                             | ALP Australian Labor Party (ALP)                                                  | $17,500         |
-|                                             | Liberal NSW - John Howard Fundraiser The Westin                                   | $17,500         |
-|                                             | Liberal Party - North Sydney                                                      | $17,430         |
-|                                             | Australian Democrats Queensland Division - QLD                                    | $17,404         |
-|                                             | Liberal Party of Australia SA Division LIB-SA                                     | $17,350         |
-|                                             | ONA                                                                               | $17,300         |
-|                                             | Australian Labor Party (NSW)                                                      | $17,280         |
-|                                             | LIB-TAS Liberal Party of Australia - Tasmanian Division                           | $17,200         |
-|                                             | Liberal Party of Australia, Vic Division - LIB-VIC                                | $17,093         |
-|                                             | Australian Labor Party (ALP)/ALP                                                  | $17,066         |
-|                                             | ALP CANNING ALP-WA                                                                | $17,046         |
-|                                             | NAT - FED                                                                         | $17,038         |
-|                                             | Liberal Party of Australia (W.A. Div) Inc                                         | $17,000         |
-|                                             | GRN-ACT                                                                           | $17,000         |
-|                                             | Australian Labor Party (NSW) Gifts Pty Ltd                                        | $17,000         |
-|                                             | Australian Labor Party ALP-QLD                                                    | $16,920         |
-|                                             | Progressive Business Association (ALP-VIC)                                        | $16,900         |
-|                                             | Liberal Party of Aust LIB-FED HUME FEC                                            | $16,800         |
-|                                             | Liberal Party of Australia -VIC LIB-VIC                                           | $16,550         |
-|                                             | Australian Labor Party QLD Branch/ALP-QLD                                         | $16,500         |
-|                                             | LNP Team Quirk Brisbane / LNP-QLD                                                 | $16,500         |
-|                                             | ALP (Membership of Federal Labor Business Forum)                                  | $16,500         |
-|                                             | Nationals Federal                                                                 | $16,500         |
-|                                             | Australian Labor Party/ALP FED                                                    | $16,500         |
-|                                             | Australian Labor Party - Federal                                                  | $16,500         |
-|                                             | National Party of Australia (NSW)                                                 | $16,500         |
-|                                             | LIB Fed                                                                           | $16,500         |
-|                                             | The Millenium Forum - The Liberal Party of Australia (NSW Division)               | $16,500         |
-|                                             | Liberal Party SA                                                                  | $16,436         |
-|                                             | Nats (WA)                                                                         | $16,340         |
-|                                             | LIB-VIC Higgins 200 Club                                                          | $16,274         |
-|                                             | National Party of Australia NSW                                                   | $16,117         |
-|                                             | The 500 Club                                                                      | $16,060         |
-|                                             | Stable Population Party of Australia                                              | $16,000         |
-|                                             | Green and Gold Foundation                                                         | $16,000         |
-|                                             | LIBERAL DEMOCRATIC PARTY LDP                                                      | $15,856         |
-|                                             | Australian Labor Party (Victorian Branch)/ALP-VIC                                 | $15,850         |
-|                                             | Liberal Party of Western Australia                                                | $15,620         |
-|                                             | Liberal Party of Australia, NSW Division (NSW) LIB-NSW                            | $15,620         |
-|                                             | LNP-QLD (Fairfax FDC)                                                             | $15,500         |
-|                                             | LIB-NSW - NSW Division                                                            | $15,500         |
-|                                             | The 500 Club (VIC) (Liberal Party - Victorian Division)                           | $15,500         |
-|                                             | Australian Democrats - WA Division                                                | $15,469         |
-|                                             | Liberal Party of Australia NSW/LIB-NSW                                            | $15,465         |
-|                                             | Australian Labor Party NSW                                                        | $15,450         |
-|                                             | Australians Against Further Immigration - NATIONAL                                | $15,420         |
-|                                             | Australian Labor Party - (NSW)                                                    | $15,300         |
-|                                             | Australian Democrats ACT Division - ACT                                           | $15,249         |
-|                                             | Casey Business Briefing Club                                                      | $15,225         |
-|                                             | Liberal Party of Australia (SA)                                                   | $15,020         |
-|                                             | Advance Aus Ltd                                                                   | $15,000         |
-|                                             | The Liberal Party of Australia - Victoria Division                                | $15,000         |
-|                                             | ALP NSW BRANCH                                                                    | $15,000         |
-|                                             | WA Labor Party ALP-WA                                                             | $15,000         |
-|                                             | Liberal Party of Australia (Victoria Division)                                    | $15,000         |
-|                                             | ALP - FED (2016 Federal Conference - Business program)                            | $15,000         |
-|                                             | LIB - ACT                                                                         | $15,000         |
-|                                             | Liberal Party LIB-FED                                                             | $15,000         |
-|                                             | Rise Up Australia Party (RUA)                                                     | $15,000         |
-|                                             | Derryn Hinch's Justice Party                                                      | $15,000         |
-|                                             | LIBERAL PARTY OF AUSTRALIA / LIB-NSW                                              | $15,000         |
-|                                             | NATIONAL PARTY OF AUSTRALIA BARNABY JOYCE - NEW ENGLAND FEDERAL ELECTION CAMPAIGN | $15,000         |
-|                                             | Liberal Party of Australia (VIC Division) (paid to Kooyong 200 Club)              | $15,000         |
-|                                             | LPA TAS Division                                                                  | $15,000         |
-|                                             | NEN                                                                               | $15,000         |
-|                                             | Australian Labor Party - NSW Branch - ALP-QLD                                     | $15,000         |
-|                                             | CLP                                                                               | $15,000         |
-|                                             | LIB-WA - Cottesloe Liberal Campaign                                               | $15,000         |
-|                                             | Country Liberal Party (CLP-NT)                                                    | $15,000         |
-|                                             | ALP-NSW - NSW Branch Federal Campaign Account                                     | $15,000         |
-|                                             | Liberal Party (W.A. Div) Inc                                                      | $15,000         |
-|                                             | LIB-FED Liberal Party of Australia                                                | $15,000         |
-|                                             | LIB-VIC Liberal Party, Victorian Division                                         | $15,000         |
-|                                             | Chifley Research Centre                                                           | $15,000         |
-|                                             | Australian Labor Party (NT)                                                       | $15,000         |
-|                                             | Australian Labor Party/ ALP-WA                                                    | $15,000         |
-|                                             | Liberal Party Campaign 2010                                                       | $15,000         |
-|                                             | CLP The Territory Party                                                           | $14,995         |
-|                                             | Liberal Party of Australia - VIC - LIB-VIC                                        | $14,975         |
-|                                             | Liberal Party Australia                                                           | $14,950         |
-|                                             | Liberal Party of Australia (Lib-FED)                                              | $14,685         |
-|                                             | ACCI                                                                              | $14,619         |
-|                                             | ALP - Australian Labor Party (National Secretariat)                               | $14,528         |
-|                                             | Australian Labor Party - SA Branch ALP-SA                                         | $14,404         |
-|                                             | Liberal Party of Australia Tasmanian Division / LIB-TAS                           | $14,300         |
-|                                             | Australian Labor Party (VIC)                                                      | $14,200         |
-|                                             | The Nationals                                                                     | $14,170         |
-|                                             | Advance Aus Ltd - Advance Australia                                               | $14,167         |
-|                                             | Australian Labor Party - Victoria (ALP - VIC)                                     | $14,105         |
-|                                             | Liberal Party of Australia / LIB-NSW                                              | $14,100         |
-|                                             | GETUP                                                                             | $14,000         |
-|                                             | The Australian Greens (GRN-VIC) (Victorian Branch)                                | $14,000         |
-|                                             | Liberal National Party - Art Union                                                | $14,000         |
-|                                             | Liberal Party of Aus-WA - LIB-WA                                                  | $14,000         |
-|                                             | LIB-NSW - Liberal Party of Australia NSW Division                                 | $14,000         |
-|                                             | One Nation ONA-FED                                                                | $14,000         |
-|                                             | LIB-QLD                                                                           | $13,987         |
-|                                             | Australian Labor Party - Victoria (ALP-VIC)                                       | $13,883         |
-|                                             | ALP-VIC                                                                           | $13,835         |
-|                                             | Liberal Party (Prahran 200 Club)                                                  | $13,800         |
-|                                             | Australian Labor Party (Victorian Branch) - ALP-VIC                               | $13,750         |
-|                                             | Australian Labor Party (NSW Branch                                                | $13,750         |
-|                                             | NSW Labor Business Dialogue 2009-1010                                             | $13,750         |
-|                                             | Progressive Business Association (ALP Victoria)                                   | $13,738         |
-|                                             | Progressive Business Association ALP-SA                                           | $13,650         |
-|                                             | The Nationals Federal Secretariat - NAT                                           | $13,640         |
-|                                             | ALP NSW Federal Campaign Account                                                  | $13,575         |
-|                                             | Australia Labor Party - Victoria (ALP-VIC)                                        | $13,545         |
-|                                             | The Liberal Party of Australia (NSW Division)                                     | $13,516         |
-|                                             | GRN-TAS                                                                           | $13,500         |
-|                                             | The Nationals for Regional NSW                                                    | $13,450         |
-|                                             | Australian Labor Party NSW Branch Federal Campain Account - ALP-NSW               | $13,400         |
-|                                             | Liberal Party of Aus - LIB-WA                                                     | $13,400         |
-|                                             | Nats-Federal                                                                      | $13,368         |
-|                                             | Nationals                                                                         | $13,272         |
-|                                             | CDP                                                                               | $13,260         |
-|                                             | Australian Labor Party (South Australian Branch)/ALP-SA                           | $13,230         |
-|                                             | Pauline Hanson's One Nation - Queensland                                          | $13,200         |
-|                                             | Nationals (Fed)                                                                   | $13,190         |
-|                                             | National Party of Australia - N.S.W NAT-NSW                                       | $13,030         |
-|                                             | Australian Labor Party - ALP-VIC                                                  | $13,000         |
-|                                             | Liberal Party of Australia – ACT Division                                         | $12,950         |
-|                                             | Progressive Business ALP-VIC                                                      | $12,901         |
-|                                             | Secondment - ALP-FED                                                              | $12,836         |
-|                                             | Senator On-Line                                                                   | $12,795         |
-|                                             | Liberal Party of Australia, NSW / LIB-NSW                                         | $12,730         |
-|                                             | National Party of Australia - NAT-FED                                             | $12,650         |
-|                                             | Australian Labor Party (SA Branch) / ALP-SA                                       | $12,565         |
-|                                             | Liberal Party of Aus                                                              | $12,500         |
-|                                             | LIBERAL NATIONAL SPRING HILL                                                      | $12,500         |
-|                                             | The Secular Party of Australia                                                    | $12,500         |
-|                                             | Christian Democratic Party (Fred Nile Group) WA Branch CDP-WA                     | $12,500         |
-|                                             | Australian Christians ACH-FED                                                     | $12,500         |
-|                                             | Liberal Party - ALP-SA - SA Liberal Party Appeal - Graham Ingerson                | $12,500         |
-|                                             | Family First Party - SA                                                           | $12,500         |
-|                                             | Liberal Party of Australia (Victorian Division) / LIB-VC                          | $12,445         |
-|                                             | Liberal Party of Australia LIB-ACT                                                | $12,445         |
-|                                             | National Party of Australia (S.A.) Inc. - SA                                      | $12,350         |
-|                                             | Liberal Party of Australia (Victorian Division)/LIB-VIC                           | $12,310         |
-|                                             | Liberal National Party - QLD                                                      | $12,272         |
-|                                             | Liberal Party of Australia VIC - Enterprise 500 Victoria                          | $12,240         |
-|                                             | Liberal Party of Western Australia Pty Ltd                                        | $12,160         |
-|                                             | LIBERAL PARTY OF AUST-NSW DIVISION (LIB-NSW)                                      | $12,000         |
-|                                             | Liberal National Party QLD LNP-QLD                                                | $12,000         |
-|                                             | Liberal Party of Australia - Tasmanian Division/LIB-TAS                           | $12,000         |
-|                                             | LIB (VIC) (Membership of Enterprise 500)                                          | $12,000         |
-|                                             | Lib-Tas                                                                           | $12,000         |
-|                                             | Liberal Party of Australia - Tasmanian Division (LIB-TAS)                         | $12,000         |
-|                                             | LIB (Sturt FEC)                                                                   | $12,000         |
-|                                             | Liberal Party of Australia (Lib-VIC)                                              | $12,000         |
-|                                             | Michael Danby's Re-Election Campaign - ALP - Vic                                  | $12,000         |
-|                                             | Australian Labor Party (Victoria Branch)                                          | $12,000         |
-|                                             | Family First Party - SA (FFP-SA)                                                  | $12,000         |
-|                                             | Millenium Forum / LIB-NSW                                                         | $12,000         |
-|                                             | CLP Gifts and Legacies Pty Ltd                                                    | $12,000         |
-|                                             | National Party Australia                                                          | $11,870         |
-|                                             | Liberal Party of Australia - Federal                                              | $11,850         |
-|                                             | Liberal Party of Australia - VIC Branch                                           | $11,725         |
-|                                             | Liberal Party of Australia (LIB/VIC)                                              | $11,700         |
-|                                             | Liberal Party of Australia (VIC Division) Entreprise 500                          | $11,500         |
-|                                             | NATS-FED                                                                          | $11,450         |
-|                                             | LIB (57th Federal Council - Bus. Observer)                                        | $11,250         |
-|                                             | Australian Labor Party - ALP-QLD                                                  | $11,176         |
-|                                             | Australian Labor Party (NSW)                                                      | $11,000         |
-|                                             | ALP - QLD (2015 State Conference & Business program)                              | $11,000         |
-|                                             | LNP - QLD (2016 State Conference & Q Forum subscription)                          | $11,000         |
-|                                             | LPA NSW Division Incorporated - North Sydney Forum                                | $11,000         |
-|                                             | LIB - Conference: Business Observers Programme                                    | $11,000         |
-|                                             | LIB-WA - WA Conference                                                            | $11,000         |
-|                                             | Liberal Party (Fed)                                                               | $11,000         |
-|                                             | North Sydney Forum - LIB-FED                                                      | $11,000         |
-|                                             | LIB-FED: Business Observer Program, 56th Fed. Council                             | $11,000         |
-|                                             | The Liberal Party of Australia LIB-FED                                            | $11,000         |
-|                                             | Millenium Forum - Liberal Party of NSW                                            | $11,000         |
-|                                             | The National Federal Secretariat                                                  | $11,000         |
-|                                             | ALP Victoria                                                                      | $11,000         |
-|                                             | NSW Liberal Millenium Forum 2009-2010                                             | $11,000         |
-|                                             | Millenium Forum / Lib-NSW                                                         | $11,000         |
-|                                             | Millenium Forum Business Membership                                               | $11,000         |
-|                                             | Jewish Labor Forum                                                                | $11,000         |
-|                                             | Labour Movement Education Association Inc.                                        | $11,000         |
-|                                             | Pauline Hansons One Nation QLD                                                    | $10,908         |
-|                                             | Bayside Forum                                                                     | $10,870         |
-|                                             | Liberal Party of Australia - LIB-FED                                              | $10,800         |
-|                                             | Lib-NSW Federal Campaign                                                          | $10,700         |
-|                                             | Liberal Party of Australia - NSW (LIB-NSW)                                        | $10,641         |
-|                                             | Tasmania First Party                                                              | $10,500         |
-|                                             | LNP-QLD - LNP Conference                                                          | $10,450         |
-|                                             | Liberal Party of Australia - LIB-VIC                                              | $10,250         |
-|                                             | ALP NSW Division - ALP-NSW                                                        | $10,250         |
-|                                             | The Brisbane Future Committee                                                     | $10,250         |
-|                                             | Save the ADI Site Party - NSW                                                     | $10,230         |
-|                                             | Liberal Party of Australia LIB-WA                                                 | $10,150         |
-|                                             | SA Progressive Business / ALP-SA                                                  | $10,099         |
-|                                             | Liberal Party VIC Division                                                        | $10,035         |
-|                                             | advance australia                                                                 | $10,000         |
-|                                             | Australian Conservatives (SA)                                                     | $10,000         |
-|                                             | ALP-QLD (Dawson)                                                                  | $10,000         |
-|                                             | LIB Party of Australia (WA Division)                                              | $10,000         |
-|                                             | Liberal Party of Australia LIB FED                                                | $10,000         |
-|                                             | ALP NSW EDEN MONARO CAMPAIGN                                                      | $10,000         |
-|                                             | LIB-FEC                                                                           | $10,000         |
-|                                             | LIBERAL PARTY OF AUSTRALIA (LIB-FED)                                              | $10,000         |
-|                                             | LIBERAL PARTY OF AUST- NO.2 A/C (LIB-FED)                                         | $10,000         |
-|                                             | ALP - QLD (2015 State Conference - Business program)                              | $10,000         |
-|                                             | Enterprise 500 Vic Connecting Leaders/LIB-VIC                                     | $10,000         |
-|                                             | LIBERAL VICTORIA/LIB-VIC                                                          | $10,000         |
-|                                             | LIBERAL PARTY OF AUSTRALIA (VIC) DIVISION KOOYONG ELECTORATE CONFERENCE           | $10,000         |
-|                                             | LIBERAL PARTY OF AUSTRALIA (Federal)                                              | $10,000         |
-|                                             | Liberal Party of Australia (S.A. Division) LIB-SA                                 | $10,000         |
-|                                             | LNP BRISBANE                                                                      | $10,000         |
-|                                             | Lib-FED Menzies Research Centre                                                   | $10,000         |
-|                                             | Liberal Party of Aust LIB-FED Warringah FEC                                       | $10,000         |
-|                                             | NATIONALS NAT-FED                                                                 | $10,000         |
-|                                             | LIBERAL NEW SOUTH WALES                                                           | $10,000         |
-|                                             | STURT FEC                                                                         | $10,000         |
-|                                             | XEN - Nick Xenephon Team                                                          | $10,000         |
-|                                             | LPA VIC Division                                                                  | $10,000         |
-|                                             | Australian Labor Party Queensland ALP-QLD                                         | $10,000         |
-|                                             | LNP - Dickson                                                                     | $10,000         |
-|                                             | Liberal Party of Australia VIC Division (Menzies 200 Club)                        | $10,000         |
-|                                             | The Nationals (Gippsland Nationals Federal Campaign Committee)                    | $10,000         |
-|                                             | Matt Thistlewaite Campaign a/c - ALP-NSW                                          | $10,000         |
-|                                             | LIB-SA, Sturt FEC                                                                 | $10,000         |
-|                                             | LNP Ashgrove Sec/LNP-QLD                                                          | $10,000         |
-|                                             | Liberal Party of Australia - NSW Division Warringah FEC (LIB-NSW)                 | $10,000         |
-|                                             | LIB-SA/Cory Bernardi Campaign Fund                                                | $10,000         |
-|                                             | Liberal Party of NSW LIB-NSW                                                      | $10,000         |
-|                                             | Kew Electorate Conference - Liberal Party of Australia - Vic Division             | $10,000         |
-|                                             | Australian Labor Party N.S.W. Branch (Federal Account)                            | $10,000         |
-|                                             | Liberal Part NSW Division                                                         | $10,000         |
-|                                             | Senator Mathias Corman Liberal Party Camp A/C - LIB-WA                            | $10,000         |
-|                                             | Sturt FEC - LIB-SA                                                                | $10,000         |
-|                                             | LNP-QLD - Planning Forum, QLD                                                     | $10,000         |
-|                                             | NAT - Federal National Forum                                                      | $10,000         |
-|                                             | Perth Liberal Party (LIB-WA)                                                      | $10,000         |
-|                                             | NAT-NSW - National Party of Australia NSW                                         | $10,000         |
-|                                             | LIB-NSW - NSW Federal Campaign Account                                            | $10,000         |
-|                                             | Christopher Pyne (Lib Fed)                                                        | $10,000         |
-|                                             | Fairfax FDC (Libs Fed)                                                            | $10,000         |
-|                                             | Dunkley FEC (Libs Fed)                                                            | $10,000         |
-|                                             | LIberal Party of Australia Lib-Fed                                                | $10,000         |
-|                                             | Enterprise 500 Victoria                                                           | $10,000         |
-|                                             | Australian Labor Party - Isaacs                                                   | $10,000         |
-|                                             | Liberal Party of Australia (Vic Div) Kooyong 200 Club                             | $10,000         |
-|                                             | LIB-VIC - Liberal Party of Australia (Victorian Division)                         | $10,000         |
-|                                             | LNP unit FDC Dickson                                                              | $10,000         |
-|                                             | LNP - Queensland                                                                  | $10,000         |
-|                                             | Lindsay FEC - ALP-FED                                                             | $10,000         |
-|                                             | Liberal Party of Aust - VIC                                                       | $10,000         |
-|                                             | ALP-NT Karama Fundraising Acct                                                    | $10,000         |
-|                                             | CLP-NT - Lia Finocchiaro                                                          | $10,000         |
-|                                             | Australian Labor Party ALP FED                                                    | $10,000         |
-|                                             | Liberal Party WA                                                                  | $10,000         |
-|                                             | LNP Mermaid Beach                                                                 | $10,000         |
-|                                             | Camden State Campaign Labor NSW                                                   | $10,000         |
-|                                             | ALP - Macarthur (Nick Bleasdale)(ALP-NSW)                                         | $10,000         |
-|                                             | ALP - Hume (Robin Saville)(ALP-NSW)                                               | $10,000         |
-|                                             | ALP-Tasmania Lyons (Dick Adams)                                                   | $10,000         |
-|                                             | Five Hundred Club                                                                 | $10,000         |
-|                                             | The Liberal Party of Australia, Sturt FEC                                         | $10,000         |
-|                                             | Liberal Party (LIB-VIC)                                                           | $10,000         |
-|                                             | Liberal Party - Simcha Federal                                                    | $10,000         |
-|                                             | Liberal Party - Federal Heffernan                                                 | $10,000         |
-|                                             | Federal Labor Business Forum                                                      | $10,000         |
-|                                             | ALP Maribyrnong FEA - Shorten Account                                             | $10,000         |
-|                                             | Mike Kelly MP Eden-Monaro Re-Election campaign                                    | $10,000         |
-|                                             | K Rudd - Griffith FEC Account - ALP QLD                                           | $10,000         |
-|                                             | Liberal Party of Australia, Hartley FEC                                           | $10,000         |
-|                                             | Liberal Party of Australia, Sturt FEC                                             | $10,000         |
-|                                             | Millenium Forum Sponsor Business - Liberal Party of Australia - NSW               | $10,000         |
-|                                             | Millenium Forum - Liberal Party of Australia (NSW Division)                       | $10,000         |
-|                                             | Australian Greens Queensland Branch                                               | $10,000         |
-|                                             | Family First Party - VIC - VIC                                                    | $10,000         |
-|                                             | Australian Hotels Association                                                     | $10,000         |
-|                                             | Socialist Equality Party                                                          | $10,000         |
-|                                             | Hope Party Australia - ethics equality ecology - NATIONAL                         | $9,870          |
-|                                             | ALP-WA (ALP Brand Election Campaign - Gary Gray)                                  | $9,500          |
-|                                             | Liberal Party NSW Division - Bradfield                                            | $9,410          |
-|                                             | LIB - VIC (Enterprise Victoria)                                                   | $9,405          |
-|                                             | Liberal Party of Australia (NSW) Ryde Forum                                       | $9,400          |
-|                                             | Australian Labor Party - VIC / ALP-VIC                                            | $9,250          |
-|                                             | National Party of Australia (NSW Branch)                                          | $9,250          |
-|                                             | LIB-SA Liberal Party of Australia (SA Division)                                   | $9,200          |
-|                                             | The Great Australians - QLD                                                       | $9,143          |
-|                                             | Liberal Party of Australia – Tasmanian Division                                   | $9,000          |
-|                                             | Liberal Party of Australia /LIB-NSW                                               | $9,000          |
-|                                             | NAT -FED                                                                          | $8,800          |
-|                                             | LIB -SA                                                                           | $8,800          |
-|                                             | National Party of Australia (NAT)                                                 | $8,800          |
-|                                             | Progressive Business (ALP-VIC)                                                    | $8,765          |
-|                                             | Australian Labor Party (Vic Branch)                                               | $8,755          |
-|                                             | NAT-NSW National Party of Australia - N.S.W.                                      | $8,700          |
-|                                             | LPA - LIB-FED                                                                     | $8,550          |
-|                                             | ALP LINDSAY ALP-NSW                                                               | $8,532          |
-|                                             | Liberal National Party of Queensland - LNP-QLD                                    | $8,495          |
-|                                             | Federal Labor Business Forum / ALP-FED                                            | $8,470          |
-|                                             | National Party of Australia (NSW Division)                                        | $8,400          |
-|                                             | Australian Labor Party - WA Branch                                                | $8,376          |
-|                                             | LNP-QLD - State LNP Annual Conference - Toowoomba                                 | $8,300          |
-|                                             | LNP-QLD - LNP National Convention - Brisbane                                      | $8,300          |
-|                                             | The National Party - NAT-WA                                                       | $8,280          |
-|                                             | National Party of Australia (NAT-FED)                                             | $8,250          |
-|                                             | Progressive Business Forum - registration fee                                     | $8,250          |
-|                                             | Liberal Party - 54th Federal Council / LIB-FED                                    | $8,250          |
-|                                             | Australian Labor Party - NSW / ALP-NSW                                            | $8,220          |
-|                                             | Liberal Party of Australia (NSW Division) Ryde Forum                              | $8,175          |
-|                                             | Australian Labor Party (South Australian Branch) / ALP-SA                         | $8,155          |
-|                                             | Australian Labor Party (National Secretariat) ALP-FED                             | $8,100          |
-|                                             | ALP-ACT                                                                           | $8,093          |
-|                                             | Socialist Alliance - NATIONAL                                                     | $8,020          |
-|                                             | Liberal Vic, Kooyong Electorate Conference                                        | $8,000          |
-|                                             | Labor Friends of Israel - Australian Labor Party - Vic                            | $8,000          |
-|                                             | Ian Macfarlane, Member for Groom/Liberal Party of Australia                       | $8,000          |
-|                                             | LNP-QLD - LNP Forward Brisbane Leadership                                         | $8,000          |
-|                                             | ALP - Cunningham (Sharon Bird)(ALP-NSW)                                           | $8,000          |
-|                                             | ALP - Throsby (Stephen Jones)(ALP-NSW)                                            | $8,000          |
-|                                             | Lyndhurst SECC                                                                    | $8,000          |
-|                                             | Australian Progressive Alliance - NATIONAL                                        | $8,000          |
-|                                             | Cook FEC                                                                          | $8,000          |
-|                                             | LIB - Fed                                                                         | $7,970          |
-|                                             | Mike Kelly, Member for Monaro/ALP                                                 | $7,817          |
-|                                             | LNP - QLD (Business event with Minister)                                          | $7,700          |
-|                                             | Liberal Party QLD                                                                 | $7,700          |
-|                                             | Australian Labor Party - ACT Branch                                               | $7,622          |
-|                                             | Senator David Johnston, Liberal Party of Australia (WA Div)                       | $7,600          |
-|                                             | Federal Labor Business Exchange (ALP-FED)                                         | $7,500          |
-|                                             | The Nationals NAT-FED                                                             | $7,500          |
-|                                             | ALP-QLD                                                                           | $7,500          |
-|                                             | Nick Xenophon Team                                                                | $7,500          |
-|                                             | Robertson Labor Campaign - ALP-NSW                                                | $7,500          |
-|                                             | Aston Liberal Federal Electorate Conference LIB-VIC                               | $7,500          |
-|                                             | The Liberal Party of Australia - Kooyong Electorate                               | $7,500          |
-|                                             | Perth Trades Hall Inc                                                             | $7,364          |
-|                                             | Liberal Party of Australia - Tasmania Division - LIB-TAS                          | $7,300          |
-|                                             | QLD ALP                                                                           | $7,150          |
-|                                             | WA-ALP                                                                            | $7,050          |
-|                                             | Liberal Party of Australia - SA - LIB-SA                                          | $7,036          |
-|                                             | Liberal Democratic Party (WA Branch)                                              | $7,000          |
-|                                             | Christian Democratic Party (Fred Nile Group)                                      | $7,000          |
-|                                             | John McEwen House Pty Ltd (NAT-FED)                                               | $7,000          |
-|                                             | LNP Bowman Federal Divisional/LNP-QLD                                             | $7,000          |
-|                                             | LIB-VIC Higgins Electorate Conference                                             | $7,000          |
-|                                             | ALP                                                                               | $7,000          |
-|                                             | Mackellar Business Forum (Liberal Party)                                          | $7,000          |
-|                                             | Mackellar Business Forum - LIB                                                    | $7,000          |
-|                                             | Liberal Party LIB-WA                                                              | $7,000          |
-|                                             | LPA VIC Division - LIB-VIC                                                        | $7,000          |
-|                                             | ALP-QLD / Australian Labor Party - QLD                                            | $7,000          |
-|                                             | Liberal Party of Australia (VIC Division) Menzies Reserach Cen                    | $6,982          |
-|                                             | LIB-QLD: Corporate Observer M/Ship - Type A/B                                     | $6,875          |
-|                                             | Australian Labor Party - ALP-SA                                                   | $6,740          |
-|                                             | NSW Nationals                                                                     | $6,738          |
-|                                             | Liberal Party of Australia - SA                                                   | $6,660          |
-|                                             | Liberal - NSW                                                                     | $6,636          |
-|                                             | Lib - Fed: Business Briefing Program                                              | $6,600          |
-|                                             | LIB-ACT - Federal Secretariat                                                     | $6,600          |
-|                                             | National Party VIC                                                                | $6,600          |
-|                                             | LIB-SA (Hindmarsh FEC)                                                            | $6,552          |
-|                                             | National Party of Australia NSW Federal Campaign Account                          | $6,500          |
-|                                             | LIB-NSW - Hughes FEC Federal Campaign                                             | $6,500          |
-|                                             | Australia First Party                                                             | $6,400          |
-|                                             | Richard Torbay                                                                    | $6,340          |
-|                                             | Liberal Party of Australia - QLD Branch                                           | $6,300          |
-|                                             | Australian Labor Party - QLD/ALP-QLD                                              | $6,300          |
-|                                             | National Party of Australia - NSW (NAT-NSW)                                       | $6,250          |
-|                                             | LNP (QLD)                                                                         | $6,250          |
-|                                             | ALP (ACT)                                                                         | $6,125          |
-|                                             | ALP- NSW                                                                          | $6,100          |
-|                                             | Country Labor Party - CLR-NSW                                                     | $6,100          |
-|                                             | LPA TAS Division - LIB-TAS                                                        | $6,040          |
-|                                             | LIB - VIC (2016 State Conference - Business program)                              | $6,000          |
-|                                             | Liberal Party (National)                                                          | $6,000          |
-|                                             | Liberal National Party Qld                                                        | $6,000          |
-|                                             | Hughes Federal Campaign a/c - ALP-NSW                                             | $6,000          |
-|                                             | LIB NAT-QLD                                                                       | $6,000          |
-|                                             | SA Progressive Business Inc / ALP-SA                                              | $6,000          |
-|                                             | Phil Cleary - Independent Australia - NATIONAL                                    | $6,000          |
-|                                             | Advance Australia Party                                                           | $6,000          |
-|                                             | The Brisbane Futures Committee                                                    | $6,000          |
-|                                             | NAT-FED - National Party of Australia Federal Council                             | $5,940          |
-|                                             | National Party (Fed)                                                              | $5,940          |
-|                                             | Natural Law Party (National)                                                      | $5,816          |
-|                                             | LNP Bowman FDC                                                                    | $5,800          |
-|                                             | NAT-VIC                                                                           | $5,700          |
-|                                             | Bradfield Forum - LIB-FED                                                         | $5,700          |
-|                                             | Kooyong 200 Club                                                                  | $5,700          |
-|                                             | Australian Labor Party - ALP-NSW                                                  | $5,550          |
-|                                             | National Party of Australia – N.S.W.                                              | $5,500          |
-|                                             | National Party of Australia - N.S.W                                               | $5,500          |
-|                                             | KAP                                                                               | $5,500          |
-|                                             | LIBERAL PARTY FEDERAL FORUM (LIB-FED)                                             | $5,500          |
-|                                             | ALP-VIC (Progressive Business)                                                    | $5,500          |
-|                                             | Liberal Party of Australia (S.A Division)/LIB-SA                                  | $5,500          |
-|                                             | ALP (Dinner PM Kevin Rudd)                                                        | $5,500          |
-|                                             | Liberal Party of Australia, NSW Division (Federal Acct)                           | $5,500          |
-|                                             | LNP - FDC Dickson                                                                 | $5,500          |
-|                                             | LNP-QLD - LIberal National Party QLD                                              | $5,500          |
-|                                             | Casey Fed Election Conference (LIB)                                               | $5,500          |
-|                                             | ALP-FED: Board Room Dinner with PM Julia Gillard                                  | $5,500          |
-|                                             | North Sydney Forum - Liberal Party of Australia, NSW Division (LIB-NSW)           | $5,500          |
-|                                             | LPA VIC Divison - LIB-VIC                                                         | $5,500          |
-|                                             | Liberal Party of Australia - Millennium Forum                                     | $5,500          |
-|                                             | Millenium Forum (LIB-NSW)                                                         | $5,500          |
-|                                             | National Party of Australia - VIC / NAT-VIC                                       | $5,500          |
-|                                             | Liberal Party of Australia - VIC / LIB-VIC                                        | $5,500          |
-|                                             | Liberal Party - David Ridgway / LIB/SA                                            | $5,500          |
-|                                             | Business Observers' Programme / LIB-WA                                            | $5,500          |
-|                                             | NSW Nationals Annual General Conference                                           | $5,500          |
-|                                             | Tasmania First Party - NATIONAL                                                   | $5,485          |
-|                                             | National Party of Australia - NSW Branch                                          | $5,454          |
-|                                             | ALP BURT ALP-WA                                                                   | $5,440          |
-|                                             | Hope Party Australia - NATIONAL                                                   | $5,394          |
-|                                             | Liberal Party of Australia - LIB-SA                                               | $5,340          |
-|                                             | ALP (WA)                                                                          | $5,200          |
-|                                             | NAT-FED National Party of Australia                                               | $5,200          |
-|                                             | ALP - National Secretariat                                                        | $5,200          |
-|                                             | The Page Research Centre Ltd                                                      | $5,190          |
-|                                             | GetUp                                                                             | $5,000          |
-|                                             | Australian Conservatives ACP FED                                                  | $5,000          |
-|                                             | ALP National Secretaria                                                           | $5,000          |
-|                                             | Australian Conservatives ACP                                                      | $5,000          |
-|                                             | LIB - WA                                                                          | $5,000          |
-|                                             | ALP GREY ALP-SA                                                                   | $5,000          |
-|                                             | ALP FLYNN ALP-QLD                                                                 | $5,000          |
-|                                             | LIBERAL PARTY OF AUSTRALI/LIB-FED                                                 | $5,000          |
-|                                             | WARRINGAH LIBERAL CAMPAIGN/LIB-NSW                                                | $5,000          |
-|                                             | JULIAN LEESER'S ELECTION CAMPAIGN/LIB-NSW                                         | $5,000          |
-|                                             | AUSTRALIAN LABOR PART/ALP-ACT                                                     | $5,000          |
-|                                             | LIBERAL PARTY- FOR DR STEPHEN RUSS                                                | $5,000          |
-|                                             | Liberal Party of Australia, NSW Division / LIB/NSW                                | $5,000          |
-|                                             | Glen Lazarus Team - GLT                                                           | $5,000          |
-|                                             | LNP DICKSON                                                                       | $5,000          |
-|                                             | Liberal Party of Australia- Victorian Division                                    | $5,000          |
-|                                             | Liberal Party SA Division (Mayo FEC)                                              | $5,000          |
-|                                             | Country Labor Party/CLR-NSW                                                       | $5,000          |
-|                                             | ALP NSW Branch - Chifley FEC                                                      | $5,000          |
-|                                             | Aston Electorate Committee - LIB-VIC                                              | $5,000          |
-|                                             | LIB-SA, Hindmarsh FEC                                                             | $5,000          |
-|                                             | LIB-SA, LIB-SA, Hartley SEC                                                       | $5,000          |
-|                                             | LIB-SA, Hartley SEC                                                               | $5,000          |
-|                                             | Hunter Federal Campaign Account - ALP-NSW                                         | $5,000          |
-|                                             | Liberal Party of Australia Tasmania LIB-TAS                                       | $5,000          |
-|                                             | LNP - LNP Brisbane FDC 00260                                                      | $5,000          |
-|                                             | Liberal Party of Australia / LIB                                                  | $5,000          |
-|                                             | Eden-Monaro FEC - LIB-NSW                                                         | $5,000          |
-|                                             | LIB-WA - Dinner 2013                                                              | $5,000          |
-|                                             | LNP-QLD - Federal Budget reply                                                    | $5,000          |
-|                                             | LIB-VIC Higgins Federal Electorate Conference                                     | $5,000          |
-|                                             | Eden Monaro FEC (Lib Fed)                                                         | $5,000          |
-|                                             | Australian Labor Party - Eden Monaro Federal Campaign                             | $5,000          |
-|                                             | LIB-SA - Christopher Pyne                                                         | $5,000          |
-|                                             | LIB-SA - Matthew Williams                                                         | $5,000          |
-|                                             | LIB-SA - Andrew Southcott                                                         | $5,000          |
-|                                             | LIB-WA - Liberal Party (W.A. Division) Inc.                                       | $5,000          |
-|                                             | ALP-QLD - Australian Labor Party (State of Queensland)                            | $5,000          |
-|                                             | ALP-WA - Australian Labor Party (Western Australian Branch)                       | $5,000          |
-|                                             | Australian Labour Party (SA Branch) ALP-SA                                        | $5,000          |
-|                                             | Forward Ipswich Inc. (ALP QLD)                                                    | $5,000          |
-|                                             | Forward Ipswich Inc (ALP QLD)                                                     | $5,000          |
-|                                             | Doboy MEC ALP (ALP QLD)                                                           | $5,000          |
-|                                             | Australian Labor Party (NSW Branch) Fed                                           | $5,000          |
-|                                             | Liberal Party of Australia - VIC/LIB-VIC                                          | $5,000          |
-|                                             | Liberal Party NSW Nth Syd FEC Nthwd NS                                            | $5,000          |
-|                                             | G Ward - Liberal Party NSW                                                        | $5,000          |
-|                                             | Heads G WardLiberal South Coast                                                   | $5,000          |
-|                                             | Epping SEC Liberal NSW                                                            | $5,000          |
-|                                             | Mackellar Business Forum                                                          | $5,000          |
-|                                             | Liberal Party of Australia - Mackellar Business Forum                             | $5,000          |
-|                                             | ALP - Calare (Kevin Duffy)(ALP-NSW)                                               | $5,000          |
-|                                             | ALP Tasmania Braddon (Sid Sidebottom)                                             | $5,000          |
-|                                             | ALP Tasmania Franklin (Julie Collins)                                             | $5,000          |
-|                                             | ALP NSW (Nigel Gould)                                                             | $5,000          |
-|                                             | Liberal Party of Australia (NSW Division - Manly SEC)                             | $5,000          |
-|                                             | Liberal National Party (Jane Prentice)                                            | $5,000          |
-|                                             | Liberal National Party (QLD)                                                      | $5,000          |
-|                                             | 2010 Business Forum - Liberal Party of NSW                                        | $5,000          |
-|                                             | National Party of Australia, WA Division/ NAT-WA                                  | $5,000          |
-|                                             | Hon Jason Clare MP                                                                | $5,000          |
-|                                             | Liberal Party of Aust - Lib NSW                                                   | $5,000          |
-|                                             | Liberal Party of Australia - NSW Division - LIB NSW                               | $5,000          |
-|                                             | Michael Danby MHR - ALP Melbourne Ports                                           | $5,000          |
-|                                             | Senator Glen Sterle ALP Cmapaign                                                  | $5,000          |
-|                                             | Yvette D'ath MP ALP Petire FEC                                                    | $5,000          |
-|                                             | Bliar Campaign QLD Labor Party                                                    | $5,000          |
-|                                             | ALP - Moncreif FDE                                                                | $5,000          |
-|                                             | ALP - Forde FDE                                                                   | $5,000          |
-|                                             | Australian Labour Party - National Secretariat                                    | $5,000          |
-|                                             | The State Secretary - ALP QLD - ALP-QLD                                           | $5,000          |
-|                                             | Drummoyne State Campaign A/C ALP-NSW                                              | $5,000          |
-|                                             | ALP-TAS / Australian Labor Party - Tas                                            | $5,000          |
-|                                             | Australian Labor Party (Queensland Branch)                                        | $5,000          |
-|                                             | Lalor FEA Campaign Account Australian Labor Party National Secretariat            | $5,000          |
-|                                             | Australian Labor Party - TAS / ALP-TAS                                            | $5,000          |
-|                                             | Liberal Party of Australia - TAS / LIB-TAS                                        | $5,000          |
-|                                             | Australian Greens - TAS / GRN-TAS                                                 | $5,000          |
-|                                             | Australian Labor Party - QLD / ALP-QLD                                            | $5,000          |
-|                                             | Family First Party - QLD                                                          | $5,000          |
-|                                             | Menzies Research Centre Limited                                                   | $5,000          |
-|                                             | Liberal Lord Mayor of Brisbane                                                    | $5,000          |
-|                                             | Australian Shooters Party - NATIONAL                                              | $5,000          |
-|                                             | Parramatta Business Network                                                       | $5,000          |
-|                                             | The Chifley Research Centre Ltd                                                   | $5,000          |
-|                                             | VECCI Finance & Administration                                                    | $5,000          |
-|                                             | Mark Nevill MLC                                                                   | $5,000          |
-|                                             | Sydney Alliance Limited                                                           | $5,000          |
-|                                             | ALP Progressive Business Association                                              | $4,950          |
-|                                             | National Federal Secretariat                                                      | $4,950          |
-|                                             | Higgins 200 Club LIB VIC                                                          | $4,800          |
-|                                             | LIB VIC                                                                           | $4,700          |
-|                                             | ADD LIB                                                                           | $4,655          |
-|                                             | ALP-SA: SA Progressive Business Inc.                                              | $4,560          |
-|                                             | Lib-VIC                                                                           | $4,550          |
-|                                             | National Party of Australia - NAT-NSW                                             | $4,500          |
-|                                             | NATS - FED                                                                        | $4,500          |
-|                                             | National Party QLD                                                                | $4,500          |
-|                                             | Liberal Party of Queensland / LNP-QLD                                             | $4,400          |
-|                                             | National Party NAT-NSW                                                            | $4,400          |
-|                                             | LIB-TAS Liberal Party of Australia (Tasmanian Division)                           | $4,400          |
-|                                             | Progressive Busine Association / ALP-VIC                                          | $4,400          |
-|                                             | Murray 250 Club                                                                   | $4,400          |
-|                                             | Liberal Party of Australia, NSW Division/LIB-NSW                                  | $4,385          |
-|                                             | Victorian ALP                                                                     | $4,354          |
-|                                             | Labor Party of NSW                                                                | $4,344          |
-|                                             | Tony McGrane                                                                      | $4,300          |
-|                                             | The Nationals - NSW                                                               | $4,204          |
-|                                             | Hellenic 200 Club                                                                 | $4,200          |
-|                                             | Australian Progressive Alliance - SA                                              | $4,176          |
-|                                             | Australian Labor Party - SA - ALP-SA                                              | $4,175          |
-|                                             | Liberal Party of Australia (SA) LIB                                               | $4,150          |
-|                                             | Liberal Party VIC                                                                 | $4,134          |
-|                                             | Liberal Party VIC Division - Flinders                                             | $4,100          |
-|                                             | LIB-VIC - Boardroom Policy Forum                                                  | $4,091          |
-|                                             | Australian Labor Party - 2012 State Conference Business Observers/ALP-FED         | $4,050          |
-|                                             | Democratic Socialist Electoral League                                             | $4,038          |
-|                                             | APL-QLD                                                                           | $4,000          |
-|                                             | Pat Farmer/LIB-NSW                                                                | $4,000          |
-|                                             | LIB-SA (Carmen Garcia Campaign)                                                   | $4,000          |
-|                                             | LIB-FED Liberal Party of Australia (Federal Secretariat)                          | $4,000          |
-|                                             | Liberal Party of Australia VIC Branch                                             | $4,000          |
-|                                             | Lib - Fed: Annual Gala Dinner                                                     | $4,000          |
-|                                             | LIB-NSW - LIberal Party of Aust. Paterson FEC                                     | $4,000          |
-|                                             | Nationals (NSW Fed a/c)                                                           | $4,000          |
-|                                             | LNP Headquarters                                                                  | $4,000          |
-|                                             | Australian Labor Party (QLD)/ALP-QLD                                              | $4,000          |
-|                                             | ALP-Tasmania Bass (Geoff Lyons)                                                   | $4,000          |
-|                                             | Nationals Party                                                                   | $4,000          |
-|                                             | Australian Democrats SA Division                                                  | $4,000          |
-|                                             | Young National Party of Australia - NATIONAL                                      | $4,000          |
-|                                             | Warringah Marginal Seats Fund                                                     | $4,000          |
-|                                             | Progressive Labour Party - NATIONAL                                               | $3,986          |
-|                                             | Liberal Party (NSW)                                                               | $3,950          |
-|                                             | LIB-VIC Casey Federal Electorate Conference                                       | $3,890          |
-|                                             | LIB-WA (500 Club)                                                                 | $3,880          |
-|                                             | Progressive Bus. Assoc. - ALP-FED                                                 | $3,850          |
-|                                             | ALP KINGSFORD SMITH ALP-NSW                                                       | $3,765          |
-|                                             | National Party of Australia - NAT                                                 | $3,760          |
-|                                             | LIB-VIC Kooyong 200 Club                                                          | $3,750          |
-|                                             | Australian Federation Party Western Australia                                     | $3,727          |
-|                                             | ALP NSW Page Federal Campaign - ALP-NSW                                           | $3,600          |
-|                                             | ALP NSW McMahon FEC - ALP-NSW                                                     | $3,600          |
-|                                             | Liberal Party of Australia - Tas Division                                         | $3,600          |
-|                                             | Liberal Party of Australia - Bennelong FEC                                        | $3,600          |
-|                                             | Progressive Business - VIC - EFT                                                  | $3,514          |
-|                                             | Australian Labor Party (Victorian Division)                                       | $3,500          |
-|                                             | ALP (VIC) (Subscription to Progressive Business)                                  | $3,500          |
-|                                             | Liberal Party SA - Norwood SEC                                                    | $3,500          |
-|                                             | Enterprise 500 (Vic Lib)                                                          | $3,500          |
-|                                             | LNP - unit Tennyson Ward                                                          | $3,500          |
-|                                             | SA Progressive Business Inc (ALP-SA)                                              | $3,500          |
-|                                             | LPA WA Division - LIB-WA                                                          | $3,500          |
-|                                             | Pat Reilly                                                                        | $3,500          |
-|                                             | The Aged and Disability Pensioners Party - VIC                                    | $3,500          |
-|                                             | Platinum Circle - LPA QLD Division - LIB-QLD                                      | $3,490          |
-|                                             | Australian Labor Party VIC                                                        | $3,427          |
-|                                             | Liberal Party of Australia LIB-SA                                                 | $3,345          |
-|                                             | LNP - QLD (Q Forum business event subscription)                                   | $3,300          |
-|                                             | LNP-QLD - LNP Conference - Brisbane                                               | $3,300          |
-|                                             | LIB-VIC (Enterprise 500 - Vic Fed Election Launch)                                | $3,300          |
-|                                             | LIB-TAS (Private Dinner - 30/08/13)                                               | $3,300          |
-|                                             | LIB-NSW (2014 Fed Budget Dinner)                                                  | $3,300          |
-|                                             | Australian Labor Party - ALP-ACT                                                  | $3,300          |
-|                                             | ALP-NSW - ALP McMahon Federal Campaign                                            | $3,300          |
-|                                             | Liberal National Party - LNP-QLD                                                  | $3,300          |
-|                                             | Progressive Business Association / ALP - VIC                                      | $3,300          |
-|                                             | National Party of Australia - NSW / NAT-NSW                                       | $3,300          |
-|                                             | Milennium Forum - LPA - LIB-VIC                                                   | $3,300          |
-|                                             | Pauline Hanson's One Nation - NSW                                                 | $3,300          |
-|                                             | Australian Labor Party ALP-NSW                                                    | $3,273          |
-|                                             | Australian Labor Party - ALP-WA                                                   | $3,260          |
-|                                             | GRN - WA                                                                          | $3,200          |
-|                                             | Progressive Business Associate - State Budget Breakfast / ALP-VIC                 | $3,190          |
-|                                             | Liberal Party of Australia - NSW / LIB-NSW                                        | $3,180          |
-|                                             | Australian Labor Party (N.S.W. Branch)/ALP-NSW                                    | $3,150          |
-|                                             | Liberal Party of Australia NSW Division - LIB-NSW                                 | $3,100          |
-|                                             | The Warringah Club                                                                | $3,100          |
-|                                             | Paul Fletcher / LIB-FED                                                           | $3,083          |
-|                                             | ALP NSW Branch - Grayndler                                                        | $3,007          |
-|                                             | GetUp ltd                                                                         | $3,000          |
-|                                             | STUART FEDERAL ELECTORATE/LIB-FED                                                 | $3,000          |
-|                                             | PORTS RE-ELECTION/ALP-FED                                                         | $3,000          |
-|                                             | Australian Labor Party (South Australia)                                          | $3,000          |
-|                                             | Liberal National Party of Queensland (LNP-QLD)                                    | $3,000          |
-|                                             | LIB-WA Liberal Party (WA Divisin) Inc                                             | $3,000          |
-|                                             | LIB-NSW (2013 Fed Campaign Dinner with Hon Tony Abbott)                           | $3,000          |
-|                                             | Australian Labor NSW Branch Barton Federal Campaign - ALP-NSW                     | $3,000          |
-|                                             | Liberal Party VIC - Enterprise 500 Victoria                                       | $3,000          |
-|                                             | Liberal Party VIC Division - Flinders                                             | $3,000          |
-|                                             | LNP-QLD - LNP Ryan Fund                                                           | $3,000          |
-|                                             | LNP-Qld                                                                           | $3,000          |
-|                                             | NAT-NSW - National Cowper Electorate Council                                      | $3,000          |
-|                                             | LIB-VIC - Liberal Party Melbourne Victorian Division                              | $3,000          |
-|                                             | ALP-NSW - NSW Branch Blaxland Federal Campaign                                    | $3,000          |
-|                                             | ALP-NSW - Eden - Monaro Re - Election Campaign Federal Labor                      | $3,000          |
-|                                             | New England FRC Nat-Fed                                                           | $3,000          |
-|                                             | ALP NSW Branch - Deb O'Neill                                                      | $3,000          |
-|                                             | Liberal Party of Australia/LIB FED                                                | $3,000          |
-|                                             | Labor Party VIC                                                                   | $3,000          |
-|                                             | Liberal Party of Australia NSW Divison                                            | $3,000          |
-|                                             | LIB-FED: Budget Reply Luncheon                                                    | $3,000          |
-|                                             | Dobell Federal Campaign (Australian Labor Party)                                  | $3,000          |
-|                                             | Liberal Party Sydney SEC                                                          | $3,000          |
-|                                             | Ripon SECC                                                                        | $3,000          |
-|                                             | Melbourne SECC                                                                    | $3,000          |
-|                                             | Mitcham SECC                                                                      | $3,000          |
-|                                             | Seymour SECC                                                                      | $3,000          |
-|                                             | Wills FEA                                                                         | $3,000          |
-|                                             | Liberal Party of Australia Dinner - A. J. Clark AM                                | $3,000          |
-|                                             | United Trade & Labour Council of South Australia                                  | $3,000          |
-|                                             | Liberal Party - Benambra Electorate Council                                       | $3,000          |
-|                                             | Australian Labor Party - Legacies and Gifts Ltd                                   | $3,000          |
-|                                             | Australian Reform Party - NATIONAL                                                | $3,000          |
-|                                             | LIB-NSW Liberal Party of Australia NSW Division                                   | $2,920          |
-|                                             | Liberal Party of Australia SA Division                                            | $2,908          |
-|                                             | Aust Labor Party                                                                  | $2,900          |
-|                                             | Country Labor Party - NSW                                                         | $2,900          |
-|                                             | Higgins 200 Club LIB-VIC                                                          | $2,873          |
-|                                             | Casey Business Briefing - LIB-VIC                                                 | $2,860          |
-|                                             | CLR-NSW                                                                           | $2,850          |
-|                                             | National Party of Australia (S.A.) Inc.                                           | $2,800          |
-|                                             | Liberal Party of Australia - Cook FEC                                             | $2,743          |
-|                                             | Nationls (NSW)                                                                    | $2,727          |
-|                                             | The Platinum Circle (LNP-QLD)                                                     | $2,700          |
-|                                             | ALP New South Wales Branch/ALP-NSW                                                | $2,690          |
-|                                             | ALP - ACT Branch                                                                  | $2,682          |
-|                                             | SA Progressive Business ALP-SA                                                    | $2,640          |
-|                                             | Liberal Party of Australia Hindmarsh FEC LIB                                      | $2,600          |
-|                                             | Tasmanian Labor                                                                   | $2,500          |
-|                                             | Liberal Party Australia LIB-FED                                                   | $2,500          |
-|                                             | Liberal Party of Australia LNP-QLD                                                | $2,500          |
-|                                             | Enterprise 500                                                                    | $2,500          |
-|                                             | LIB-VIC Menzies 200 Club                                                          | $2,500          |
-|                                             | LNP Mt Coot-tha SEC                                                               | $2,500          |
-|                                             | LNP - Gladstone SEC                                                               | $2,500          |
-|                                             | ALP (NSW Branch) Blaxland FCA - ALP-NSW                                           | $2,500          |
-|                                             | Liberal Party Wannon - LIB-VIC                                                    | $2,500          |
-|                                             | Higgins Electorate Conference - LIB-VIC                                           | $2,500          |
-|                                             | Fowler Federal Campaign Account - ALP-NSW                                         | $2,500          |
-|                                             | LNP - LNP Moreton FDC                                                             | $2,500          |
-|                                             | ALP - Fed: Federal Budget Night Dinner                                            | $2,500          |
-|                                             | Australian Labor Party - SA Progressive Business - ALP-SA                         | $2,500          |
-|                                             | Liberal Party Geraldton                                                           | $2,500          |
-|                                             | Baulkham Hills SEC                                                                | $2,500          |
-|                                             | Andrew Constance - LIB - NSW                                                      | $2,500          |
-|                                             | Wollondilly                                                                       | $2,500          |
-|                                             | The Bradfield Forum                                                               | $2,500          |
-|                                             | Australian Democrats - ACT Division                                               | $2,500          |
-|                                             | Liberal Party of Australia - Victoria Division                                    | $2,450          |
-|                                             | Liberal Party of Australia - LIB-NSW                                              | $2,320          |
-|                                             | Liberal Party NSW Division - Paterson                                             | $2,300          |
-|                                             | LIB-VIC - Evening brief - Hockey                                                  | $2,273          |
-|                                             | Liberal Party VIC - Enterprise 500 Victoria                                       | $2,272          |
-|                                             | ENTERPRISE VICTORIA/LIBERAL PARTY LIB-VIC                                         | $2,250          |
-|                                             | Democratic Labor Party (DLP) - Queensland Branch                                  | $2,200          |
-|                                             | Australian Labor Party (Victorian Branch) (paid to Progressive Business)          | $2,200          |
-|                                             | ALP (VIC) (Dinner held by Progressive Business)                                   | $2,200          |
-|                                             | ALP (VIC) (Dinnwe held by Progressive Business)                                   | $2,200          |
-|                                             | LNP-QLD - Function 18/12/13                                                       | $2,200          |
-|                                             | Australian Labor Party NSW Branch Federal Capaign Account - ALP-NSW               | $2,200          |
-|                                             | LIB-TAS - Tasmanian Division                                                      | $2,200          |
-|                                             | ALP-QLD - Queensland Party                                                        | $2,200          |
-|                                             | ALP NSW Branch - Anthony Albanese                                                 | $2,200          |
-|                                             | Austrlaian Labor Party                                                            | $2,200          |
-|                                             | Australian Labor Party (QLD) ALP                                                  | $2,200          |
-|                                             | Liberal Party of Australia - Citizen Din                                          | $2,200          |
-|                                             | Liberal Party of Australia - NSW LIB-NSW                                          | $2,200          |
-|                                             | Casey Business Briefing Club Melbourne - LIB-VIC                                  | $2,200          |
-|                                             | Progressive Business - VIC-EFT                                                    | $2,199          |
-|                                             | Catering for ALP Lunch                                                            | $2,188          |
-|                                             | Sheraton on the Park - Plibersek function - ALP                                   | $2,167          |
-|                                             | Liberal Party of Australia (S.A. Division) / LIB-SA                               | $2,150          |
-|                                             | ALP Bruce FEA                                                                     | $2,145          |
-|                                             | Liberal Party of Australia NSW Division - Bega                                    | $2,100          |
-|                                             | Liberal Party of Australia NSW Division - Mackellar                               | $2,100          |
-|                                             | ALP-VIC - Australian Labor Party (Victorian Branch)                               | $2,100          |
-|                                             | Liberal Party of Aust                                                             | $2,100          |
-|                                             | LPA NSW Division - LIB-NSW                                                        | $2,080          |
-|                                             | LIB -VIC Liberal Party of Australia (Victorian Division)                          | $2,000          |
-|                                             | LIB - NSW (Business event with Minister)                                          | $2,000          |
-|                                             | ALP - FED (Business event with Shadow Ministers)                                  | $2,000          |
-|                                             | ALP FEC LILLEY ALP-QLD                                                            | $2,000          |
-|                                             | Liberal Party of Australia - SA Division (Mayo FEC)                               | $2,000          |
-|                                             | LNP WIDE BAY                                                                      | $2,000          |
-|                                             | Liberal Party of Australia (Victorian Division) Lib VIC                           | $2,000          |
-|                                             | Lib-WA Federal Campaign                                                           | $2,000          |
-|                                             | Liberal Party - VIC Division                                                      | $2,000          |
-|                                             | LPA SA Division                                                                   | $2,000          |
-|                                             | Australian Labor Party (South Australian Branch) (ALP-SA)                         | $2,000          |
-|                                             | LIB-VIC (The Higgins Federal Electorate Conference)                               | $2,000          |
-|                                             | Liberal Party of Australia (Tas Branch)                                           | $2,000          |
-|                                             | LNP Bonner FDC - LIB-NSW                                                          | $2,000          |
-|                                             | LIB-VIC Liberal Party of Victoria (Victorian Division)                            | $2,000          |
-|                                             | ALP (2014 Fed Budget Reply Dinner)                                                | $2,000          |
-|                                             | Liberal Party of Australia (VIC Division) (paid to Higgins 200 Club)              | $2,000          |
-|                                             | Liberal Party Tasmania                                                            | $2,000          |
-|                                             | Australian Labor Party - ALP - (NSW Federal Campaign Account)                     | $2,000          |
-|                                             | LNP - Team Quirk LNP                                                              | $2,000          |
-|                                             | LNP-QLD - Oxley FDC (federal fundraising)                                         | $2,000          |
-|                                             | LIB-VIC - Annual Dinner 2012                                                      | $2,000          |
-|                                             | LNP-QLD - Prentice                                                                | $2,000          |
-|                                             | LNP Wide Bay FDC                                                                  | $2,000          |
-|                                             | Lib - Qld: Tim Mander Dinner                                                      | $2,000          |
-|                                             | ALP- NSW - Hunter Federal Campaign                                                | $2,000          |
-|                                             | ALP-NSW - Fowler Federal Campaign Account                                         | $2,000          |
-|                                             | R Sutton (Nats WA)                                                                | $2,000          |
-|                                             | Casey FEC (Libs Fed)                                                              | $2,000          |
-|                                             | ALP NSW Branch - Chris Hayes                                                      | $2,000          |
-|                                             | ALP NSW Branch - Tanya Plibersek                                                  | $2,000          |
-|                                             | Liberal Party NSW Division - Paterson                                             | $2,000          |
-|                                             | Platinum Circle - Liberal National Party                                          | $2,000          |
-|                                             | Australian Labor Party - NSW - ALP-NSW                                            | $2,000          |
-|                                             | Jamie Parker Greens for Balmain                                                   | $2,000          |
-|                                             | The Greens (Inner Sydney Branch)                                                  | $2,000          |
-|                                             | LIB-QLD: Done Doing Can Do Dinner                                                 | $2,000          |
-|                                             | ALP-QLD - Ipswich                                                                 | $2,000          |
-|                                             | LNP-QLD - Forward Brisbane Leadership                                             | $2,000          |
-|                                             | Liberal Party WA - Mt Lawley Campaign                                             | $2,000          |
-|                                             | LNP Mansfield (LNP QLD)                                                           | $2,000          |
-|                                             | ALP WA (Stephen Smith)                                                            | $2,000          |
-|                                             | ALP - Parkes (Andrew Brooks)(ALP-NSW)                                             | $2,000          |
-|                                             | ALP-WA - Swan (Tim Hammond)                                                       | $2,000          |
-|                                             | Forrest Campaign Account                                                          | $2,000          |
-|                                             | Gary Gray ALP Brand Campaign Account                                              | $2,000          |
-|                                             | Cowper Electorate Council - LIB-NSW                                               | $2,000          |
-|                                             | Platinum Circle - LIB-QLD                                                         | $2,000          |
-|                                             | ALP (NSW Branch) Bennelong Campaign                                               | $2,000          |
-|                                             | Greek Aust Conservative Coalition                                                 | $2,000          |
-|                                             | Australian Liberal Party                                                          | $2,000          |
-|                                             | Barton & Hughes Fedrral Campaign Account. (Joint)                                 | $2,000          |
-|                                             | Kogarah                                                                           | $2,000          |
-|                                             | LNP - Bowman                                                                      | $2,000          |
-|                                             | Mayo Federal Electorate Convention                                                | $2,000          |
-|                                             | Federal ALP                                                                       | $2,000          |
-|                                             | Ballarat FEA / ALP-VIC                                                            | $2,000          |
-|                                             | Labor Business Roundtable / ALP-WA                                                | $2,000          |
-|                                             | Ballarat Election Campaign / ALP-VIC                                              | $2,000          |
-|                                             | Ballarat Election Campaign                                                        | $2,000          |
-|                                             | Victorian Labor / ALP-VIC                                                         | $2,000          |
-|                                             | The ACT Greens - ACT                                                              | $2,000          |
-|                                             | Richmond FEC                                                                      | $2,000          |
-|                                             | Holland Park MEC                                                                  | $2,000          |
-|                                             | Warringah Club                                                                    | $2,000          |
-|                                             | Socialist Alliance - NSW                                                          | $2,000          |
-|                                             | Robert Oakshott                                                                   | $2,000          |
-|                                             | Nuclear Disarmament Party of Australia - NATIONAL                                 | $2,000          |
-|                                             | Australia First Party - NATIONAL                                                  | $2,000          |
-|                                             | National Party of Australia (SA) Inc                                              | $2,000          |
-|                                             | NSW Liberal Women's Forum A/C                                                     | $2,000          |
-|                                             | Lib - Fed                                                                         | $1,999          |
-|                                             | Australian Labor Party ACT Branch                                                 | $1,999          |
-|                                             | Progressive Business Association - ALP-VIC                                        | $1,980          |
-|                                             | ALP-ACT: Dinner w/ Bill Shorten ACT Legislative Assembly                          | $1,980          |
-|                                             | Progressive Business ALP-VIC                                                      | $1,980          |
-|                                             | ONA - FED                                                                         | $1,946          |
-|                                             | Construction Forestry Mining & Energy Indust. Union of Emp. QLD                   | $1,946          |
-|                                             | Victorian Employers' Chamber of Commerce & Industry                               | $1,909          |
-|                                             | LNP-QLD - Policy Discussion - State Budget 2014                                   | $1,900          |
-|                                             | Lib - QLD: Queensland State Budget Lunch                                          | $1,900          |
-|                                             | Lib - ACT: Event at Parliament House                                              | $1,900          |
-|                                             | Lib - QLD: Tim Mander/Bronwyn Bishop Dinner                                       | $1,900          |
-|                                             | CED-Fed                                                                           | $1,900          |
-|                                             | ALP NSW Branch - Grenville Campaign                                               | $1,900          |
-|                                             | Pauline Hanson's One Nation - Western Australia                                   | $1,900          |
-|                                             | ALP-VIC John Brumby                                                               | $1,898          |
-|                                             | NBLF on Sustainable Development                                                   | $1,855          |
-|                                             | Liberal Party of Australia - Bradfield FEC                                        | $1,820          |
-|                                             | Liberal Party of Australia - SA Division                                          | $1,818          |
-|                                             | LIB-VIC - Boardroom Dinner Hockey                                                 | $1,818          |
-|                                             | Kevin Rudd                                                                        | $1,800          |
-|                                             | ALP-ACT: Briefing with The Hon. Julia Gillard                                     | $1,750          |
-|                                             | Michael Danby MHR, Federal Member for Melb. Ports                                 | $1,750          |
-|                                             | LIB-VIC Monash Club                                                               | $1,740          |
-|                                             | Catering ALP for Lunch                                                            | $1,718          |
-|                                             | Liberal Democratic Party (NSW Branch)                                             | $1,700          |
-|                                             | Australian Labor Party (N.S.W. Branch) / ALP-NSW                                  | $1,700          |
-|                                             | LIB-SA (Rachel Anderson's Adelaide SEC Business Breakfast 11/02/14)               | $1,700          |
-|                                             | Lindsay FEC - ALP-NSW                                                             | $1,700          |
-|                                             | ALP-NSW - Lindsay FEC                                                             | $1,700          |
-|                                             | Australian Labor Party - NSW - Wollondilly State Campaign                         | $1,700          |
-|                                             | Queensland Research Pty Ltd                                                       | $1,700          |
-|                                             | Progressive Business Post Budget Boardroom Lunch                                  | $1,699          |
-|                                             | Sheraton on the Park - Bradbury function - ALP                                    | $1,673          |
-|                                             | LNP - QLD (Business policy briefing event)                                        | $1,650          |
-|                                             | Australian Labor Party (N.S.W. branch)                                            | $1,650          |
-|                                             | LNP-QLD - Q Forum Women of Influence Series                                       | $1,650          |
-|                                             | Liberal Party of Aust Tasmanian Divisn                                            | $1,650          |
-|                                             | Liberal Party of Australia (TAS) - LIB-TAS                                        | $1,650          |
-|                                             | ALP (Fed)                                                                         | $1,650          |
-|                                             | Milennium Forum                                                                   | $1,650          |
-|                                             | ALP VIC Division - ALP-VIC                                                        | $1,650          |
-|                                             | ALP NSW Branch - Susan Templeman                                                  | $1,600          |
-|                                             | VIC-LIB Dunkley Electorate Conference                                             | $1,600          |
-|                                             | Labor Business Roundtable                                                         | $1,600          |
-|                                             | LNP-QLD (Sportsman's Lunch 2014)                                                  | $1,550          |
-|                                             | Australian Labor Party - VIC - ALP-VIC                                            | $1,550          |
-|                                             | Australian Labor Party - SA                                                       | $1,540          |
-|                                             | Melinda Pavey - NAT - NSW                                                         | $1,540          |
-|                                             | Liberal Party NSW (LIB-NSW)                                                       | $1,500          |
-|                                             | ALP - FED                                                                         | $1,500          |
-|                                             | Liberal Party NSW Division - Hawkesbury                                           | $1,500          |
-|                                             | LIB - NSW (Federal Budget event)                                                  | $1,500          |
-|                                             | Australian Labor Party - (Victorian Division)                                     | $1,500          |
-|                                             | Liberal Party NSW Division - Mackellar                                            | $1,500          |
-|                                             | Australian Labor Party (Western Australian Branch) / ALP-WA                       | $1,500          |
-|                                             | Liberal Party of Australia - NSW Division State Electorate Conference             | $1,500          |
-|                                             | Lib-FED Liberal Party of Australia                                                | $1,500          |
-|                                             | LIB (VIC) (Business Dinner Forum)                                                 | $1,500          |
-|                                             | LIB-SA (David Ridgeway's Port Lincoln Swim with Tuna)                             | $1,500          |
-|                                             | LPA - SA Divison - LIB-SA                                                         | $1,500          |
-|                                             | LNP Maranora Divisional Council/LNP-QLD                                           | $1,500          |
-|                                             | ALP Australian Labor Party National Secretariat                                   | $1,500          |
-|                                             | National Party of Australia NSW Federal Campaign - NAT-NSW                        | $1,500          |
-|                                             | ALP NSW (Hunter) - ALP-NSW                                                        | $1,500          |
-|                                             | LIB-WA - Dinner Cormann                                                           | $1,500          |
-|                                             | Lib - VIC: Boardroom Policy Forum                                                 | $1,500          |
-|                                             | LIB-VIC - Liberal Party Melbourne Vic                                             | $1,500          |
-|                                             | ALP NSW Branch - Jason Clare                                                      | $1,500          |
-|                                             | Liberal National Party QLD/LNP-QLD                                                | $1,500          |
-|                                             | Liberal Party NSW Division - Wakehurst                                            | $1,500          |
-|                                             | Liberal Party NSW DIvision - Manly                                                | $1,500          |
-|                                             | Liberal Party of Australia (NSW Division - Wollondilly SEC)                       | $1,500          |
-|                                             | Bundoora SECC                                                                     | $1,500          |
-|                                             | Senator Glen Sterle Campaign Account/ ALP-FED                                     | $1,500          |
-|                                             | Londonderry                                                                       | $1,500          |
-|                                             | Infrastructure Business Forum / ALP-ACT                                           | $1,500          |
-|                                             | Bradfield Conference / LIB-NSW                                                    | $1,500          |
-|                                             | Prospect FEC - ALP-FED                                                            | $1,500          |
-|                                             | Bass 200 Club                                                                     | $1,500          |
-|                                             | Non-Custodial Parents Party - NATIONAL                                            | $1,500          |
-|                                             | Pauline Hanson's One Nation - SA                                                  | $1,500          |
-|                                             | Young Liberal Movement of Australia                                               | $1,500          |
-|                                             | Friends of Barry O'Farrell                                                        | $1,500          |
-|                                             | Christian Democratic Party (Fred Nile Group) WA                                   | $1,500          |
-|                                             | Australian Democrats - QLD Division Inc                                           | $1,500          |
-|                                             | Christian Democratic Party (Fred Nile Group) QLD                                  | $1,500          |
-|                                             | ALP - ACT                                                                         | $1,490          |
-|                                             | ALP-VIC - Tim Holding                                                             | $1,471          |
-|                                             | Liberal Party of Australia SA                                                     | $1,453          |
-|                                             | LIB-VIC: Monash Club Dinner - Hon. T Abbott                                       | $1,450          |
-|                                             | ALP-VIC Tim Pallas                                                                | $1,440          |
-|                                             | LNP - unit Ashgrove                                                               | $1,430          |
-|                                             | Doltone House - Combet lunch - ALP                                                | $1,416          |
-|                                             | ALP Vic Branch                                                                    | $1,400          |
-|                                             | LIB-VIC - Enterprise 500 Vic                                                      | $1,364          |
-|                                             | LIB-VIC - Boardroom Dinner Robb                                                   | $1,364          |
-|                                             | ALP - Boardroom Dinner Bill Shorten                                               | $1,364          |
-|                                             | Democratic Labour Party - WA Branch                                               | $1,363          |
-|                                             | ALP National Sectretariat                                                         | $1,363          |
-|                                             | ALP NSW Branch - Grayndler Campaign                                               | $1,360          |
-|                                             | The Nationals for Regional Aust.                                                  | $1,350          |
-|                                             | Australian Labor Party ACT                                                        | $1,315          |
-|                                             | Liberal Party - LIB TAS                                                           | $1,300          |
-|                                             | Kooyong 200                                                                       | $1,300          |
-|                                             | National Liberal Australia                                                        | $1,300          |
-|                                             | Five Hundred Club - 2010 Annual Post Budget Breakfast - LIB-VIC                   | $1,281          |
-|                                             | Lib - VIC: Annual State Post Budget Breakfast                                     | $1,275          |
-|                                             | The Liberal Party of Australia (Victoria Division) LIB-VIC                        | $1,263          |
-|                                             | National Party of Victoria (NAT-VIC)                                              | $1,250          |
-|                                             | ALP NSW Branch Blaxland Federal Campaign - ALP-NSW                                | $1,250          |
-|                                             | Liberal Party of Australia/LIB-VIC                                                | $1,250          |
-|                                             | ALP - WA (Business event)                                                         | $1,232          |
-|                                             | Platinum Circle (LNP-QLD)                                                         | $1,200          |
-|                                             | LIB (The Platinum Circle Dinner)                                                  | $1,200          |
-|                                             | LIB-VIC Dunkley Flinders Events                                                   | $1,200          |
-|                                             | NAT - National Budget                                                             | $1,200          |
-|                                             | VIC-LIB Higgins 200 Club                                                          | $1,200          |
-|                                             | SA-ALP                                                                            | $1,200          |
-|                                             | ALP-TAS (M O'Byrne)                                                               | $1,200          |
-|                                             | ALP VIC Branch                                                                    | $1,150          |
-|                                             | Progressive Business Association - Corporate Membership                           | $1,150          |
-|                                             | ALP-VIC - Labor Party dinner                                                      | $1,125          |
-|                                             | ALP - FED (Federal Budget reply event)                                            | $1,100          |
-|                                             | LIB- VIC                                                                          | $1,100          |
-|                                             | Lib-Vic Federal Campaign - VIC                                                    | $1,100          |
-|                                             | ALP (National Secretariat - Gary Gray Event on 07/07/2014)                        | $1,100          |
-|                                             | National Party of Australia - VIC Branch                                          | $1,100          |
-|                                             | Lib - Qld: Federal Budget Reply Lunch                                             | $1,100          |
-|                                             | Higgins Electorate (Fed Lib)                                                      | $1,100          |
-|                                             | Nationals (Vic)                                                                   | $1,100          |
-|                                             | Liberal Party of Australia - Senator Mathias Cormann                              | $1,100          |
-|                                             | ALP-VIC (progressive business)                                                    | $1,100          |
-|                                             | ALP (Sub-continental group) (NSW Branch)                                          | $1,100          |
-|                                             | The Endeavour Consulting Group                                                    | $1,100          |
-|                                             | Higgins 200 Club (LIB-FED)                                                        | $1,100          |
-|                                             | Liberal Party of Australia NSW Div                                                | $1,100          |
-|                                             | Hughes Federal Campaign Account                                                   | $1,100          |
-|                                             | Australian Labor Party NSW Branch function                                        | $1,100          |
-|                                             | Clarence Campaign (The Hon Craig Knowles)                                         | $1,100          |
-|                                             | Liberal Party NSW Division - Cook                                                 | $1,050          |
-|                                             | Endeavour Business Forum / LIB-NSW                                                | $1,050          |
-|                                             | Liberal Democratic Party (ACT Branch)                                             | $1,000          |
-|                                             | Liberal Part of Australia SA Division - Dunstan                                   | $1,000          |
-|                                             | NAT - VIC                                                                         | $1,000          |
-|                                             | Liberal Party NSW Division - Penrith                                              | $1,000          |
-|                                             | Liberal National Party - Moncrieff                                                | $1,000          |
-|                                             | LIB-WA                                                                            | $1,000          |
-|                                             | ALP- WA                                                                           | $1,000          |
-|                                             | LIB - VIC (Higgins FEC)                                                           | $1,000          |
-|                                             | ALP NSW Branch - McMahon                                                          | $1,000          |
-|                                             | Liberal Party NSW Division (Macarthur)                                            | $1,000          |
-|                                             | LIB-TAS Liberal Party of Australia – Tasmanian Division                           | $1,000          |
-|                                             | Liberal Party - LIB NSW                                                           | $1,000          |
-|                                             | Australian Labor Party ALP-VIC                                                    | $1,000          |
-|                                             | Liberal Party of Australia - SA Fisher SEC                                        | $1,000          |
-|                                             | Bradfield Forum Lindfield - LIB-NSW                                               | $1,000          |
-|                                             | LPA - NSW Division - LIB-NSW                                                      | $1,000          |
-|                                             | LPA - Mayo Federal Electorate - LIB-SA                                            | $1,000          |
-|                                             | Aust. Labour Party                                                                | $1,000          |
-|                                             | ALP - National Secretariat (2014 Fed Budget Reply)                                | $1,000          |
-|                                             | Michael Danby's Re-Election - ALP - Vic                                           | $1,000          |
-|                                             | Bayswater Electorate Conference - LIB - Vic                                       | $1,000          |
-|                                             | Joel Fitzgibbon, Member for Hunter/ALP                                            | $1,000          |
-|                                             | Australian Labour Party NSW Branch                                                | $1,000          |
-|                                             | Liberal Party of Australia (News South Wales Division) (LIB-NSW)                  | $1,000          |
-|                                             | LNP - Brisbane FDC                                                                | $1,000          |
-|                                             | LNP-QLD - Ryan FDC (federal fundraising)                                          | $1,000          |
-|                                             | LNP Fairfax DC                                                                    | $1,000          |
-|                                             | LIB-QLD Dickson Account                                                           | $1,000          |
-|                                             | Lib - VIC: Budget Week Cocktail Party                                             | $1,000          |
-|                                             | Lib - NSW: Federal Budget Reply Dinner                                            | $1,000          |
-|                                             | LIB-NSW - LIberal Party NSW Bradfield FEC                                         | $1,000          |
-|                                             | ALP (FED)                                                                         | $1,000          |
-|                                             | Dunkley Fec (Fed Lib)                                                             | $1,000          |
-|                                             | LIB-SA - Sturt FEC                                                                | $1,000          |
-|                                             | ALP NSW Branch - Sen. Matt Thistlethwaite                                         | $1,000          |
-|                                             | ALP NSW Branch - Tony Burke                                                       | $1,000          |
-|                                             | LNP-QLD Brisbane FDC                                                              | $1,000          |
-|                                             | ALP NSW Branch - Watson                                                           | $1,000          |
-|                                             | Forward Brisbane Leadership - LNP QLD                                             | $1,000          |
-|                                             | ALP QLD Branch - Inala                                                            | $1,000          |
-|                                             | ALP QLD Branch - Brisbane                                                         | $1,000          |
-|                                             | LNP Macgregor Ward Campaign (LNP QLD)                                             | $1,000          |
-|                                             | LNP Sunnybank                                                                     | $1,000          |
-|                                             | Higgins Electorate Conference - LIB-FED                                           | $1,000          |
-|                                             | LNP Toowoomba North                                                               | $1,000          |
-|                                             | Liberal Party Australia/LIB-FED                                                   | $1,000          |
-|                                             | ALP NSW Branch - Maroubra                                                         | $1,000          |
-|                                             | ALP NSW Branch - Granville                                                        | $1,000          |
-|                                             | Canning Liberal Campaign                                                          | $1,000          |
-|                                             | Rankin FEC                                                                        | $1,000          |
-|                                             | Karawatha LNP Campaign (LNP QLD)                                                  | $1,000          |
-|                                             | ALP (ALP QLD)                                                                     | $1,000          |
-|                                             | ALP NSW Warringah (Hugh Zochling)                                                 | $1,000          |
-|                                             | Liberal Party Federal Campaign Assistance Programme                               | $1,000          |
-|                                             | LNP/Dickson                                                                       | $1,000          |
-|                                             | Australian Labor Party - Everton Campaign                                         | $1,000          |
-|                                             | Liberal Party of Australia - Casey Federal Electorate                             | $1,000          |
-|                                             | LNP - Samford Qld                                                                 | $1,000          |
-|                                             | Liberal Party - Tony Abbott's Warringah 1000 Forum                                | $1,000          |
-|                                             | Australian Labor Party / ALP-WA                                                   | $1,000          |
-|                                             | ALP Kogarah Campaign Account                                                      | $1,000          |
-|                                             | Liberal Party NSW Division - North Sydney FEC                                     | $1,000          |
-|                                             | Liberal Party (Ashford SEC)                                                       | $1,000          |
-|                                             | ALP (NSW) Branch Bennelong Fed Campaig                                            | $1,000          |
-|                                             | ALP (NSW Branch) EFT                                                              | $1,000          |
-|                                             | NSW Liberal Party (NSW Division)                                                  | $1,000          |
-|                                             | ALP-VIC / Australian Labor Party - VIC                                            | $1,000          |
-|                                             | Warringah Federal Electorate Conference                                           | $1,000          |
-|                                             | Lib-Vic                                                                           | $1,000          |
-|                                             | QLD Growth Management Summit Dinner / ALP-QLD                                     | $1,000          |
-|                                             | Frankston SECC / ALP-VIC                                                          | $1,000          |
-|                                             | Marrickville State Campaign                                                       | $1,000          |
-|                                             | ALP-TAS (Bacon)                                                                   | $1,000          |
-|                                             | Australian Labor Party - WA/ALP - WA                                              | $1,000          |
-|                                             | Aston Electoral Office - LIB-NSW                                                  | $1,000          |
-|                                             | Lang Holdings Aust Pty Ltd                                                        | $1,000          |
-|                                             | Max Christmas Camp                                                                | $1,000          |
-|                                             | Brett Murray                                                                      | $1,000          |
-|                                             | Chesterfield Evans                                                                | $1,000          |
-|                                             | Pauline Hanson's One Nation - WA                                                  | $1,000          |
-|                                             | Young Liberal Movement                                                            | $1,000          |
-|                                             | Australian Democrats - VIC Division                                               | $1,000          |
-|                                             | LNP - QLD (Business event with Shadow Minister)                                   | $990            |
-|                                             | LIB - WA (500 Club)                                                               | $990            |
-|                                             | Australian Labor party (Victoria)                                                 | $990            |
-|                                             | NAT (Budget Speech Drinks 13/5/14)                                                | $990            |
-|                                             | ALP NSW Branch - Dinner with P.M.                                                 | $990            |
-|                                             | ACT Labor - ALP-ACT                                                               | $990            |
-|                                             | Labor Party SA                                                                    | $990            |
-|                                             | VIC-LIB Kooyong 200 Club                                                          | $990            |
-|                                             | ALP - Vic                                                                         | $990            |
-|                                             | Liberal Party NSW Division - Willoughby                                           | $990            |
-|                                             | Casey federal Electorate - LIB-VIC                                                | $950            |
-|                                             | Progressive Business Assoc.                                                       | $934            |
-|                                             | ALP-NSW - Shadow Ministry Lunch 30 Nov 2012 (Fed campaign)                        | $909            |
-|                                             | NAT-NSW - Boardroom Lunch (Fed Campaign)                                          | $909            |
-|                                             | Liberal Party of Australia - QLD                                                  | $909            |
-|                                             | ALP NSW Branch - David Bradbury                                                   | $900            |
-|                                             | Granville                                                                         | $900            |
-|                                             | SA Progressive Business (ALP-SA)                                                  | $900            |
-|                                             | Progressive Business - Annual Dinner                                              | $895            |
-|                                             | LIB-VIC Dunkley Blue Ribbon Club                                                  | $850            |
-|                                             | Bradfield Forum (Liberal Party of Australia)                                      | $850            |
-|                                             | Victoria Trades Hall                                                              | $840            |
-|                                             | LIB-VIC                                                                           | $825            |
-|                                             | LNP - QLD (Q Forum business event)                                                | $825            |
-|                                             | LNP/Karawatha                                                                     | $825            |
-|                                             | Willoughby Sec - Liberal Party                                                    | $810            |
-|                                             | Liberal Party of Australia - WA Branch                                            | $803            |
-|                                             | Keira                                                                             | $800            |
-|                                             | North Sydney FEC                                                                  | $800            |
-|                                             | Liberal Party Australia - NSW - LIB-NSW                                           | $785            |
-|                                             | NAT-FED - National Party of Australia Federal Campaign                            | $770            |
-|                                             | Liberal Party of Australia - TAS LIB-TAS                                          | $770            |
-|                                             | Liberal Party of Australia (Tas Division)                                         | $770            |
-|                                             | LIB-SA (Boothby FEC)                                                              | $750            |
-|                                             | ALP-SA (Kaurna Fundraiser 23/1/14)                                                | $750            |
-|                                             | Liberal Party VIC Division                                                        | $750            |
-|                                             | ALP WA - Rockingham                                                               | $750            |
-|                                             | ALP NT - Wanguni                                                                  | $750            |
-|                                             | National Party (WA) Inc                                                           | $750            |
-|                                             | ALP NSW Branch - Marrickville                                                     | $750            |
-|                                             | Duncan Gay - NAT - NSW                                                            | $750            |
-|                                             | Liberal Party - Berowra FEC                                                       | $750            |
-|                                             | Australian Labor Party - QLD - ALP-QLD                                            | $740            |
-|                                             | LIB-VIC - Raffle Tickets                                                          | $728            |
-|                                             | warringah independent                                                             | $725            |
-|                                             | ALP-SA (SA Progressive Dinner 20/11/13)                                           | $700            |
-|                                             | ALP NSW Branch - Christina Keneally Dinner                                        | $700            |
-|                                             | ALP NSW Branch - Laurie Ferguson                                                  | $700            |
-|                                             | Liberal Party Tasmania Division                                                   | $700            |
-|                                             | Liberal Party of Australia - NSW - LIB-NSW                                        | $700            |
-|                                             | Liberal Party NSW Division - North Sydney                                         | $681            |
-|                                             | LIB (Bayside Forum Annual Dinner)                                                 | $660            |
-|                                             | National Party of Australia - VIC - NAT-VIC                                       | $660            |
-|                                             | Democratic Labor Party (DLP) - WA Branch                                          | $660            |
-|                                             | Mark Bishop ALP Senate Campaign Committee Account                                 | $660            |
-|                                             | CLP-NT - Solomon Federal Acct                                                     | $650            |
-|                                             | Liberal Party of Australia (Lib-FED) (Bradfield Forum)                            | $640            |
-|                                             | Bill Glasson FDC, Liberal National Party / LNP-QLD                                | $600            |
-|                                             | Lib - NSW: Parramatta Campaign Launch Dinner                                      | $600            |
-|                                             | ALP NSW Branch - Sub. Cont. Friends of Labour                                     | $600            |
-|                                             | Australia Labor Party - SA - ALP-SA                                               | $600            |
-|                                             | ALP-QLD: Cocktail Party Hon. Andrew Fraser MP                                     | $600            |
-|                                             | National Party of Australia/NAT-FED                                               | $600            |
-|                                             | ALP - Robert McClelland Campaign - ALP-NSW                                        | $600            |
-|                                             | Liberal Party - Isobel Redmond / LIB-SA                                           | $570            |
-|                                             | Australian Labor Party NT ALP-NT                                                  | $550            |
-|                                             | Liberal Party Federal /LIB                                                        | $550            |
-|                                             | LPA NSW Division                                                                  | $550            |
-|                                             | ALP-FED Labor Business Forum                                                      | $550            |
-|                                             | Bradfield Forum                                                                   | $550            |
-|                                             | Liberal Party of Australia (Tasmanian Division)                                   | $550            |
-|                                             | Endeavour Business Forum                                                          | $550            |
-|                                             | Progressive Business - State Budget Breakfast                                     | $539            |
-|                                             | ALP QLD - Mulgrave                                                                | $500            |
-|                                             | ALP QLD - South Brisbane                                                          | $500            |
-|                                             | Liberal Part of Australia SA Division- Dunstan                                    | $500            |
-|                                             | Liberal Party of Australia VIC Division - Bulleen                                 | $500            |
-|                                             | Liberal Party of Australia VIC Division - Malvern                                 | $500            |
-|                                             | Lib-FED Menzies Research Centre - NSW                                             | $500            |
-|                                             | Australian Labor Party (ALP) - (South Australian Branch)                          | $500            |
-|                                             | Country Labor                                                                     | $500            |
-|                                             | Liberal Party NSW/LIB-NSW                                                         | $500            |
-|                                             | Liberal Party of Australia LIB-QLD                                                | $500            |
-|                                             | Liberal Party of Australia - Wentworth FEC                                        | $500            |
-|                                             | LNP-Fairfax FDC/LNP-QLD                                                           | $500            |
-|                                             | Liberal National Party Qld/LNP-QLD                                                | $500            |
-|                                             | LIB-VIC Sandringham Electorate Conference                                         | $500            |
-|                                             | ALP-SA (Campaign Insight Dinner)                                                  | $500            |
-|                                             | ALP-SA (ALP Adelaide Lunch 12/2/14)                                               | $500            |
-|                                             | Liberal Party of Australia (Lib-FED) (Bega SE)                                    | $500            |
-|                                             | Liberal Party NSW Division - Lindsay                                              | $500            |
-|                                             | Liberal National Party LNP-QLD (The Platinum Circle)                              | $500            |
-|                                             | S Marshall - LIB-SA                                                               | $500            |
-|                                             | Liberal Party of Aus-SA - LIB-SA                                                  | $500            |
-|                                             | Lib - NSW: 2013 Federal Budget Reply Dinner                                       | $500            |
-|                                             | Lib - Vic: Budget Week Dinner at Parliament House                                 | $500            |
-|                                             | ALP NSW Branch - McKell Dinner                                                    | $500            |
-|                                             | The Nationals - National Policy Forum - NAT-FED                                   | $500            |
-|                                             | Macgregor LNP Campaign (LNP QLD)                                                  | $500            |
-|                                             | ALP La Trobe - ALP-VIC                                                            | $500            |
-|                                             | National Party of Australia - NSW NAT-NSW                                         | $500            |
-|                                             | Liberal-National Party - Leichhardt FDC                                           | $500            |
-|                                             | ALP Vic Branch - Lyndhurst                                                        | $500            |
-|                                             | ALP Western Metro Region                                                          | $500            |
-|                                             | Liberal Party NSW Division - Pittwater                                            | $500            |
-|                                             | Liberal Party NSW Division - Vaucluse                                             | $500            |
-|                                             | Liberal Party NSW Division - Cronulla                                             | $500            |
-|                                             | Liberal Party NSW Division - Oatley                                               | $500            |
-|                                             | Liberal Party NSW Division - Bega                                                 | $500            |
-|                                             | Liberal Party NSW Division - Maitland                                             | $500            |
-|                                             | Liberal Party NSW Division - Ryde                                                 | $500            |
-|                                             | Liberal Party NSW Division - Hornsby                                              | $500            |
-|                                             | Liberal Party NSW Division - Kiama                                                | $500            |
-|                                             | Liberal Party NSW Division - Murrumbidgee                                         | $500            |
-|                                             | ALP NSW Branch - Greenway                                                         | $500            |
-|                                             | Andrew Fraser - NAT - NSW                                                         | $500            |
-|                                             | Cook Endeavour Forum                                                              | $500            |
-|                                             | NSW Liberal Forum                                                                 | $500            |
-|                                             | Liberal Party of Aust - Wakehurst Cromer                                          | $500            |
-|                                             | Gippsland TLC                                                                     | $500            |
-|                                             | Helen Coonan                                                                      | $500            |
-|                                             | Daryl Williams                                                                    | $500            |
-|                                             | Salvatore Scevola                                                                 | $500            |
-|                                             | Federal Electorate of Sydney - Sydney FEC                                         | $500            |
-|                                             | North Sydney FEC Campaign Fund                                                    | $500            |
-|                                             | Australian Democrats - TAS Division                                               | $500            |
-|                                             | Liberal Party of Australia - ACT Division / LIB-ACT                               | $495            |
-|                                             | The National Party                                                                | $490            |
-|                                             | Liberal Party NSW Division - Warringah                                            | $490            |
-|                                             | ALP - Robert McClelland Campaign - ALP-FED                                        | $480            |
-|                                             | ALP NSW Branch - Summer Hill Campaign                                             | $454            |
-|                                             | Liberal Party NSW Division - North Shore SEC                                      | $454            |
-|                                             | ALP SA Branch                                                                     | $454            |
-|                                             | Hunter Federal Campaign Account (ALP - FED)                                       | $450            |
-|                                             | Lib - WA: Lunch with Tony Abbott                                                  | $450            |
-|                                             | Australian Labor Party - QLD Branch                                               | $450            |
-|                                             | Liberal Party NSW DIvision WSEC                                                   | $450            |
-|                                             | LIB-NSW Bradfield Forum                                                           | $450            |
-|                                             | ALP-WA (LBR)                                                                      | $440            |
-|                                             | NAT National Party of Australia                                                   | $440            |
-|                                             | Liberal National Party of Queensland - Maiwar                                     | $400            |
-|                                             | ALP VIC - Monbulk SECC                                                            | $400            |
-|                                             | LIB-VIC Enterprise 500 Vic - 2014 Enterprise 500 Victorian Annual Dinner          | $400            |
-|                                             | Chris Bowen MP Federal                                                            | $400            |
-|                                             | Australian Labor Party - Balmain State Campaign                                   | $400            |
-|                                             | Emily's List SA (ALP-FED)                                                         | $375            |
-|                                             | ALP - QLD (2016 State Budget event)                                               | $352            |
-|                                             | LIB-VIC Enterprise 500 Victoria                                                   | $350            |
-|                                             | Lib - NSW: Cook 200 Club Annual Membership                                        | $350            |
-|                                             | CJPW (LIB-FED)                                                                    | $350            |
-|                                             | CJPW Budget Night - Opposition Reply to the Budget                                | $350            |
-|                                             | National Party of Australia NSW Leaders Forum                                     | $330            |
-|                                             | Liberal Party of NSW Division - Wentworth                                         | $328            |
-|                                             | NAT - WA (Business event)                                                         | $320            |
-|                                             | LIB-VIC Forest Hill Supporters Club                                               | $315            |
-|                                             | LNP-QLD - Q Forum Event                                                           | $300            |
-|                                             | LIB-SA, Norwood SEC                                                               | $300            |
-|                                             | LIB-VIC Kooyong Federal Electorate Conference                                     | $300            |
-|                                             | Lib - SA: SEC Twilight Gold Day                                                   | $300            |
-|                                             | Blaxland Campaign Fundraising Dinner                                              | $300            |
-|                                             | Mosman Liberal Party Dinner / LIB-NSW                                             | $300            |
-|                                             | LNP--QLD                                                                          | $297            |
-|                                             | LIB (Hon. Joe Hockey talks to Spectator)                                          | $275            |
-|                                             | LIB-TAS (Petrusma)                                                                | $275            |
-|                                             | Liberal Party of Australia - SA Division (Hindmarsh FEC)                          | $272            |
-|                                             | ALP - QLD                                                                         | $264            |
-|                                             | LIB-SA, Adelaide SEC                                                              | $260            |
-|                                             | GRN                                                                               | $250            |
-|                                             | GRN - VIC                                                                         | $250            |
-|                                             | Liberal Party of Australia - Cook                                                 | $250            |
-|                                             | Liberal Party of Australia - Wakehurst SEC                                        | $250            |
-|                                             | Liberal Party of Australia SA - Bragg SEC                                         | $250            |
-|                                             | LIB-SA, Bragg SEC                                                                 | $250            |
-|                                             | LIberal Party NSW Division - Cook                                                 | $250            |
-|                                             | Liberal Party NSW Division - Lindsay                                              | $250            |
-|                                             | ALP - VIC: Donation to ALP Victoria Branch                                        | $250            |
-|                                             | LIB-VIC Dunkley Electorate Conference                                             | $250            |
-|                                             | ALP East Hills Campaign Account                                                   | $250            |
-|                                             | Liberal Party (Torrens SEC)                                                       | $250            |
-|                                             | North Sydney FEC (LIB-FED)                                                        | $250            |
-|                                             | Liberal Party of Australia (NSW) Nth Syd FEC                                      | $250            |
-|                                             | Liberal Party of Australia NSW Division - North Sydney FEC                        | $250            |
-|                                             | NATS-NSW                                                                          | $250            |
-|                                             | Deakin Executive Forum LIB-VIC                                                    | $250            |
-|                                             | North West 200 Club                                                               | $250            |
-|                                             | Liberal Party of Australia NSW Division - Goulburn                                | $245            |
-|                                             | Australian Labor Party - Kingston FEC                                             | $245            |
-|                                             | LIB-VIC Kew State Electorate Conference                                           | $243            |
-|                                             | North East TLC                                                                    | $240            |
-|                                             | ALP NSW Branch - Roberston Campaign                                               | $227            |
-|                                             | Lib - SA: Auge Dinner                                                             | $225            |
-|                                             | National Party of Australia - Victoria - NAT-VIC                                  | $220            |
-|                                             | The Nationals for Regional Australia (The Page Research Centre Ltd)               | $220            |
-|                                             | Liberal Party of Australia - Don Dunstan Foundation                               | $211            |
-|                                             | Liberal Part of Australia SA Division - Unley                                     | $200            |
-|                                             | Liberal Part of Australia SA Division - Colton                                    | $200            |
-|                                             | Country Labor Party / CLR-NSW                                                     | $200            |
-|                                             | LIB (VIC) (Dinner held by Enterprise 500)                                         | $200            |
-|                                             | Lib - VIC: Dinner celebrating 1992 Victory                                        | $200            |
-|                                             | Liberal Party of Austalia - SA - LIB-SA                                           | $200            |
-|                                             | Liberal Party of Australia - Davidson SEC                                         | $200            |
-|                                             | Aust Labor Party-Kingsgrove-Watson Fed                                            | $200            |
-|                                             | Liberal Party of Aus-Vaucluse Conf                                                | $200            |
-|                                             | ALP-NSW Branch - Watson Federal Camp                                              | $200            |
-|                                             | The Territory Green Party                                                         | $200            |
-|                                             | Liberal Party of Australia - Unley SEC                                            | $195            |
-|                                             | LNP-QLD - Function attendance                                                     | $182            |
-|                                             | LNP-QLD - QLD State Budget lunch                                                  | $182            |
-|                                             | ALP - Barton and Hughes Campaign                                                  | $182            |
-|                                             | Fed Election 2010 Countdown Dinner - Sen Fierravanti-Wells / LIB-NSW              | $180            |
-|                                             | LIB-VIC Deakin 200 Club                                                           | $175            |
-|                                             | LIB-SA (Mawson Fundraiser)                                                        | $170            |
-|                                             | Sturt Federal Electorate Committee                                                | $165            |
-|                                             | Sturt Federal Electorate Committee - LIB-SA                                       | $165            |
-|                                             | Sturt Federal Electoral Committee                                                 | $165            |
-|                                             | Platinum Forum LIB-VIC                                                            | $160            |
-|                                             | Liberal Party - Tony Smith MP Lunch / LIB-FED                                     | $160            |
-|                                             | LIB-VIC Deakin Federal Electorate Conference                                      | $155            |
-|                                             | LNP-QLD - Q Forum Women of Influence Event                                        | $150            |
-|                                             | LIB-SA (Ladies Lunch 2013)                                                        | $150            |
-|                                             | LIB-NSW (2013 Fed Election Countdown Dinner)                                      | $150            |
-|                                             | LIB-NSW (2013 Fed Election Countdown)                                             | $150            |
-|                                             | ALP-SA (EOY drinks w/ Premier + ALP)                                              | $150            |
-|                                             | National Party of Australia - NSW (NAT - NSW)                                     | $150            |
-|                                             | Lib - NSW: Federal Fundraising Dinner                                             | $150            |
-|                                             | Lib - SA: Luncheon with Marshall & Kennett                                        | $150            |
-|                                             | Nationals (NSW)                                                                   | $150            |
-|                                             | Bradfield Federal Electrate Conf-NSW                                              | $150            |
-|                                             | Sturt Liberal FEC (LIB-FED)                                                       | $150            |
-|                                             | 2009 Ku-ring-gai Business Breakfast                                               | $150            |
-|                                             | ALP-SA (Lunch with Julia Gillard)                                                 | $130            |
-|                                             | Liberal Party NSW Division - Member for Ku-ring-gai                               | $125            |
-|                                             | ALP-SA (Celebrate Hon John Hill career)                                           | $125            |
-|                                             | ALP-ACT: Testimonial Dinner                                                       | $125            |
-|                                             | Lib - NSW: Tony Abbott Birthday Function                                          | $120            |
-|                                             | Liberal Party of NSW - LIB-NSW                                                    | $120            |
-|                                             | LPA - LIB-NSW                                                                     | $120            |
-|                                             | Dame Pattie Menzies Foundation Trust                                              | $120            |
-|                                             | NAT - WA                                                                          | $110            |
-|                                             | National Party of Australia - NSW - NAT-NSW                                       | $110            |
-|                                             | Liberal Party of Australia - Epping SEC                                           | $110            |
-|                                             | LNP-QLD The Platinum Circle                                                       | $110            |
-|                                             | Matt Brown                                                                        | $110            |
-|                                             | GRN - FED                                                                         | $100            |
-|                                             | LIB-VIC Southern Metropolitan Electorate Conference                               | $100            |
-|                                             | LIB-VIC (2013 Spring Evening Briefing)                                            | $100            |
-|                                             | LIB-SA (Cocktails with Sen. Hon. Eric Abetz)                                      | $100            |
-|                                             | Lib - SA: Leadership on the Couch                                                 | $100            |
-|                                             | Lib - WA: Campaign Raffle                                                         | $100            |
-|                                             | Australian Labor Party - QLD                                                      | $100            |
-|                                             | Liberal Party NSW Division - Davidson                                             | $100            |
-|                                             | McMillan FEA                                                                      | $100            |
-|                                             | Liberal Party of Australia (WA)                                                   | $100            |
-|                                             | Chisholm Electorate Conference LIB-VIC                                            | $100            |
-|                                             | Liberal Party NSW Division - Bradfield                                            | $95             |
-|                                             | Liberal Party of Australia - Bradfield Forum - LIB-NSW                            | $95             |
-|                                             | Liberal Party Davidson (LIB-NSW)                                                  | $95             |
-|                                             | Willoughby SEC / LIB-NSW                                                          | $90             |
-|                                             | Liberal Party of Australia SA - Unley                                             | $85             |
-|                                             | Liberal Party Australia - Bradfield Forum - LIB-NSW                               | $80             |
-|                                             | LIB-WA - Economic Forum                                                           | $75             |
-|                                             | Liberal Party of Australia - Sydney CMP                                           | $75             |
-|                                             | Liberal Party SA - Sturt FEC                                                      | $70             |
-|                                             | Lib - SA: Pyne 20th event                                                         | $70             |
-|                                             | LIB-VIC South Metropolitan Electorate Conference                                  | $65             |
-|                                             | Australian Labor Party (State of Queensland) ALP-QLD                              | $63             |
-|                                             | Liberal Party NSW Division - Cook 200 Club                                        | $60             |
-|                                             | Liberal Forum NSW                                                                 | $60             |
-|                                             | LIB-VIC Box Hill Branch [105]                                                     | $55             |
-|                                             | Liberal Party of Australia - Menzies Research - LIB-NSW                           | $55             |
-|                                             | LIB-VIC Malvern State Electorate Conference                                       | $50             |
-|                                             | National Party of Australia - N.S.W. / NAT-NSW                                    | $50             |
-|                                             | ALP - ALP Ministerial Forum - Sydney                                              | $50             |
-|                                             | Lib - NSW                                                                         | $50             |
-|                                             | Mt Waverley State Electorate Conference                                           | $50             |
-|                                             | Liberal Party WA - Riverton Campaign                                              | $35             |
+| Party                                       | Donation Made To                                                                   | Total Donations |
+| ------------------------------------------- | ---------------------------------------------------------------------------------- | --------------- |
+| UAP                                         | United Australia Party                                                             | $83,929,218     |
+| LIB                                         | Liberal Party of Australia                                                         | $55,574,981     |
+| UAP                                         | Palmer United Party                                                                | $35,753,598     |
+| ALP                                         | Australian Labor Party (ALP)                                                       | $34,915,448     |
+| LIB                                         | Liberal Party of Australia - NATIONAL                                              | $20,670,189     |
+| LIB                                         | Liberal Party of Australia, NSW Division                                           | $18,192,167     |
+| ALP                                         | Australian Labor Party (N.S.W. Branch)                                             | $15,829,201     |
+| ALP                                         | Australian Labor Party (N.S.W. Branch) - NSW                                       | $15,000,239     |
+| LIB                                         | Liberal Party of Australia, NSW Division - NSW                                     | $13,184,614     |
+| LIB                                         | Liberal Party of Australia (Victorian Division)                                    | $12,739,546     |
+| LIB                                         | Liberal Party of Australia (Victorian Division) - VIC                              | $12,615,872     |
+| ALP                                         | Australian Labor Party (ALP) - NATIONAL                                            | $12,140,648     |
+| LIB                                         | Liberal National Party of Queensland                                               | $11,515,303     |
+| ALP                                         | Australian Labor Party (Victorian Branch)                                          | $10,666,403     |
+| ALP                                         | Australian Labor Party (Victorian Branch) - VIC                                    | $7,114,197      |
+| NP                                          | National Party of Australia                                                        | $6,878,898      |
+| ALP                                         | Australian Labor Party (State of Queensland)                                       | $6,822,559      |
+| LIB                                         | Liberal Party of Australia (S.A. Division)                                         | $6,717,450      |
+| LIB                                         | Liberal Party (W.A. Division) Inc.                                                 | $6,251,161      |
+| UAP                                         | Clive Palmer's United Australia Party                                              | $5,910,341      |
+| LIB                                         | Liberal Party of Australia - Federal Secretariat                                   | $5,533,148      |
+| LIB                                         | Liberal Party (W.A. Division) Inc. - WA                                            | $5,200,057      |
+| ALP                                         | Australian Labor Party (State of Queensland) - QLD                                 | $5,187,884      |
+| ALP                                         | Australian Labor Party (Western Australian Branch)                                 | $4,884,058      |
+| LIB                                         | LIB-FED                                                                            | $4,352,901      |
+| ALP                                         | Australian Labor Party (NSW Branch)                                                | $4,273,171      |
+| LIB                                         | Liberal Party (W.A. Division) Inc                                                  | $4,232,588      |
+| ALP                                         | Australian Labor Party - National Secretariat                                      | $3,970,479      |
+| LIB                                         | Liberal Party of Australia (NSW Division)                                          | $3,944,553      |
+| LIB                                         | Liberal Party of Australia - Tasmanian Division                                    | $3,662,588      |
+| ALP                                         | Australian Labor Party (Western Australian Branch) - WA                            | $3,484,631      |
+| LIB                                         | Liberal Party of Australia (VIC Division)                                          | $3,409,175      |
+| LIB                                         | Liberal Party of Australia - Queensland Division - QLD                             | $3,346,916      |
+| LIB                                         | Liberal Party of Australia (S.A. Division) - SA                                    | $2,862,564      |
+| LIB                                         | The Free Enterprise Foundation                                                     | $2,709,019      |
+| NP                                          | National Party of Australia - NATIONAL                                             | $2,580,935      |
+| ALP                                         | ALP-FED                                                                            | $2,565,899      |
+| ALP                                         | Australian Labor Party (South Australian Branch) - SA                              | $2,562,948      |
+| CEC                                         | Citizens Electoral Council of Australia - NATIONAL                                 | $2,507,236      |
+| NP                                          | National Party of Australia - N.S.W.                                               | $2,441,212      |
+| FFP                                         | Family First Party                                                                 | $2,193,200      |
+| ALP                                         | Australian Labor Party (South Australian Branch)                                   | $2,118,194      |
+| LIB                                         | Advance Australia                                                                  | $2,117,000      |
+| GRN                                         | The Australian Greens - Victoria                                                   | $2,107,984      |
+| GRN                                         | The Greens (WA) Inc                                                                | $2,055,498      |
+| ALP                                         | Australian Council of Trade Unions                                                 | $2,050,000      |
+| ALP                                         | Australian Labor Party (VIC Branch)                                                | $2,040,940      |
+| LIB                                         | Liberal Party of Australia - Victorian Division                                    | $1,823,430      |
+| ALP                                         | Australian Labor Party (Northern Territory) Branch                                 | $1,820,938      |
+| LIB                                         | LIB-NSW                                                                            | $1,797,151      |
+| GRN                                         | GRN-FED                                                                            | $1,700,295      |
+| NP                                          | National Party of Australia (Queensland) - QLD                                     | $1,593,857      |
+| NP                                          | National Party of Australia (Queensland)                                           | $1,584,011      |
+| NP                                          | National Party of Australia - N.S.W. - NSW                                         | $1,578,766      |
+| LIB                                         | LNP-QLD                                                                            | $1,568,489      |
+| LIB                                         | Liberal Party of Australia - Queensland Division                                   | $1,565,813      |
+| CLP                                         | Country Liberals (Northern Territory)                                              | $1,554,382      |
+| NP                                          | National Party of Australia (WA) Inc                                               | $1,548,931      |
+| CEC                                         | Citizens Electoral Council of Australia                                            | $1,547,924      |
+| ALP                                         | ALP-NSW                                                                            | $1,423,456      |
+| NP                                          | National Party of Australia - Victoria                                             | $1,401,609      |
+| LIB                                         | LIB-SA                                                                             | $1,347,545      |
+| ALP                                         | Australian Labor Party (ACT Branch) - ACT                                          | $1,285,949      |
+| GRN                                         | Australian Greens                                                                  | $1,266,983      |
+| Sus                                         | #Sustainable Australia                                                             | $1,187,279      |
+| KAP                                         | Katter's Australian Party                                                          | $1,160,659      |
+| LIB                                         | Liberal Party of Australia (Federal Secretariat)                                   | $1,044,288      |
+| ALP                                         | Australian Labor Party                                                             | $1,030,165      |
+| ALP                                         | ALP National Secretariat                                                           | $1,013,048      |
+| ALP                                         | ALP                                                                                | $1,004,672      |
+| GRN                                         | The Greens NSW                                                                     | $1,001,888      |
+| ALP                                         | ALP - National Secretariate                                                        | $1,000,000      |
+| LIB                                         | Liberal Party of Australia (SA Division)                                           | $984,751        |
+| ALP                                         | Australian Labor Party (National Secretariat)                                      | $977,186        |
+| LIB                                         | LIB                                                                                | $955,964        |
+| NP                                          | National Party of Australia (WA) Inc - WA                                          | $903,085        |
+| FFP                                         | Family First Party - NATIONAL                                                      | $885,670        |
+| LIB                                         | Liberal Party of Australia (WA Division) Inc                                       | $880,742        |
+| ALP                                         | Australian Labor Party - State of Queensland                                       | $871,618        |
+| CEC                                         | CEC                                                                                | $863,557        |
+| ALP                                         | Australian Labor Party (Northern Territory) Branch - NT                            | $843,328        |
+| LIB                                         | The Liberal Party of Western Australia Pty Ltd                                     | $817,377        |
+| LIB                                         | LIB - WA                                                                           | $810,375        |
+| LIB                                         | LIB-WA                                                                             | $788,591        |
+| GetUp                                       | GetUp Limited                                                                      | $787,998        |
+| ASXP                                        | Australian Sex Party                                                               | $773,540        |
+| NP                                          | NAT-FED                                                                            | $772,709        |
+| ALP                                         | ALP NSW                                                                            | $734,596        |
+| GRN                                         | Australian Greens, Victorian Branch                                                | $724,172        |
+| LIB                                         | Forward Brisbane Leadership                                                        | $719,183        |
+| ALP                                         | Progressive Business Association Inc                                               | $695,458        |
+| UAP                                         | PUP - Palmer United Party                                                          | $688,537        |
+| ALP                                         | Australian Labor Party (Tasmanian Branch) - TAS                                    | $676,932        |
+| LIB                                         | LIB-TAS                                                                            | $657,329        |
+| LIB                                         | Higgins 200 Club                                                                   | $656,774        |
+| LIB                                         | ADVANCE AUSTRALIA                                                                  | $650,000        |
+| CLP                                         | Northern Territory Country Liberal Party - NATIONAL                                | $632,078        |
+| LIB                                         | LIB-VIC                                                                            | $631,242        |
+| GRN                                         | Australian Greens (South Australia)                                                | $624,274        |
+| LIB                                         | Liberal Party of Australia (QLD Division)                                          | $611,233        |
+| Liberty ALA                                 | Australian Liberty Alliance                                                        | $595,614        |
+| ALP                                         | Progressive Business Association                                                   | $589,326        |
+| CEC                                         | CEC-FED                                                                            | $584,348        |
+| NP                                          | National Party of Australia - National Secretariat                                 | $565,874        |
+| ALP                                         | Australian Labor Party (ACT Branch)                                                | $551,444        |
+| LIB                                         | Liberal Party of Australia, NSW Division (LIB-NSW)                                 | $550,000        |
+| ALP                                         | Australian Labor Party (Tasmanian Branch)                                          | $544,029        |
+| ALP                                         | Australian Labor Party (WA Branch)                                                 | $535,414        |
+| LIB                                         | Millennium Forum                                                                   | $522,919        |
+| LIB                                         | Lib-FED                                                                            | $510,000        |
+| ALP                                         | ALP-QLD                                                                            | $506,185        |
+| ALP                                         | Australian Labor Party (ALP                                                        | $500,000        |
+| Great                                       | The Great Australian Party                                                         | $500,000        |
+| LIB                                         | Sir Charles Court Foundation                                                       | $500,000        |
+| NP                                          | National Party of Australia - NSW                                                  | $481,274        |
+| LIB                                         | Liberal Party of Australia - Tasmanian Division - TAS                              | $474,424        |
+| ALP                                         | ALP-VIC                                                                            | $453,337        |
+| GRN                                         | Queensland Greens                                                                  | $452,035        |
+| LIB                                         | Liberal Party of Australia - ACT Division                                          | $450,488        |
+| NP                                          | NAT-NSW                                                                            | $444,128        |
+| CLP                                         | Northern Territory Country Liberal Party                                           | $430,784        |
+| LIB                                         | LIB - FED                                                                          | $414,319        |
+| KAP                                         | Katter's Australian Party (KAP)                                                    | $412,282        |
+| KAP                                         | KAP-FED                                                                            | $398,455        |
+| LIB                                         | Liberal National Party                                                             | $388,818        |
+| LIB                                         | Free Enterprise Foundation                                                         | $383,000        |
+| DEM                                         | Australian Democrats - NATIONAL                                                    | $380,763        |
+| LIB                                         | LNP                                                                                | $372,082        |
+| LIB                                         | The Liberal Party of Australia                                                     | $366,151        |
+| LIB                                         | Liberal Party of Australia - ACT Division - ACT                                    | $363,518        |
+| NP                                          | NAT-WA                                                                             | $360,498        |
+| ZSteggall                                   | Warringah Independent Limited                                                      | $354,800        |
+| GRN                                         | Australian Greens, Tasmanian Branch                                                | $351,684        |
+| LIB                                         | Liberal Party of Aust NSW Division                                                 | $344,338        |
+| LIB                                         | Liberal Party of Australia LIB-FED                                                 | $332,080        |
+| ALP                                         | Australian Labor Party (SA Branch)                                                 | $329,793        |
+| DEM                                         | Australian Democrats SA Division - SA                                              | $326,315        |
+| ALP                                         | ALP-SA                                                                             | $324,729        |
+| LIB                                         | Federal Secretariat - LIB-FED                                                      | $320,000        |
+| ALP                                         | National Secretariat - ALP-FED                                                     | $312,200        |
+| LIB                                         | Liberal Party of Australia / LIB-FED                                               | $308,793        |
+| LIB                                         | Liberal Party of Australia (LIB-FED)                                               | $304,700        |
+| GRN                                         | Australian Greens - TAS                                                            | $304,171        |
+| LIB                                         | LIB - NSW                                                                          | $284,895        |
+| LIB                                         | Liberal Party of Australia - NSW                                                   | $284,127        |
+| LIB                                         | Australian Chamber of Commerce and Industry                                        | $282,634        |
+| ALP                                         | Emily's List Australia                                                             | $267,459        |
+| GRN                                         | The Greens NSW - NSW                                                               | $267,382        |
+| Flux                                        | VOTEFLUX.ORG / Upgrade Democracy!                                                  | $261,729        |
+| Christ                                      | Australian Christians                                                              | $260,303        |
+| LDP                                         | Liberal Democratic Party                                                           | $260,230        |
+| LIB                                         | Liberal Party of Australia LIB                                                     | $258,000        |
+| NP                                          | National Party of Australia - Victoria - VIC                                       | $257,472        |
+| LIB                                         | Liberal Party of Australia (VIC Division) (paid to Enterprise 500)                 | $256,700        |
+| GetUp                                       | GetUp Ltd                                                                          | $251,500        |
+| LIB                                         | Liberal Party (WA) Division Inc LIB-WA                                             | $250,000        |
+| LIB                                         | Liberal Party of Australia/ LIB                                                    | $250,000        |
+| ALP                                         | Australian Labor Party / ALP-FED                                                   | $249,800        |
+| ALP                                         | ALP - NSW                                                                          | $247,559        |
+| LIB                                         | Liberal Party of Australia (ACT Division)                                          | $245,860        |
+| ALP                                         | ALP-WA                                                                             | $245,217        |
+| ALP                                         | ALP FED                                                                            | $238,771        |
+| RPA                                         | Republican Party of Australia - NATIONAL                                           | $237,257        |
+| ALP                                         | ALP NSW Branch                                                                     | $226,490        |
+| AJP                                         | Animal Justice Party                                                               | $224,550        |
+| LIB                                         | Liberal Party of Australia - NSW Division                                          | $218,980        |
+| GRN                                         | GRN-QLD Queensland Greens                                                          | $205,000        |
+| ALP                                         | ALP (Griffith FEC)                                                                 | $200,000        |
+| ALP                                         | Australian Council of Trade Unions (ACTU)                                          | $200,000        |
+| ALP                                         | Australian Labour Party (LAB-FED)                                                  | $200,000        |
+| LIB                                         | Lib-WA                                                                             | $200,000        |
+| LIB                                         | Liberal Party (LIB-FED)                                                            | $200,000        |
+| LIB                                         | LNP QLD                                                                            | $197,490        |
+| Shooters                                    | Shooters and Fishers Party                                                         | $196,024        |
+| Sus                                         | Australian Stable Population Party                                                 | $194,320        |
+| NP                                          | NAT                                                                                | $194,106        |
+| Sus                                         | #Sustainable Population Party                                                      | $190,150        |
+| GRN                                         | The Greens (WA) Inc - NATIONAL                                                     | $188,950        |
+| LIB                                         | Liberal Party of Australia (TAS Division)                                          | $187,584        |
+| LIB                                         | Liberal Party of Australia - NSW Branch                                            | $185,822        |
+| LIB                                         | Liberal Party of Australia/LIB-FED                                                 | $183,550        |
+| LIB                                         | Liberal Party Federal Secretariat - LIB-ACT                                        | $180,000        |
+| LIB                                         | Liberal Party of Australia / LIB                                                   | $177,775        |
+| LIB                                         | Liberal National Party of Queensland LNP-QLD                                       | $176,700        |
+| LIB                                         | Liberal Party of Australia NSW Division                                            | $173,333        |
+| CLP                                         | CLP-NT                                                                             | $172,800        |
+| GRN                                         | Australian Greens - NATIONAL                                                       | $172,682        |
+| LIB                                         | Campaign for Small Business (Australian Chamber of Commerce and Industry)          | $170,928        |
+| FFP                                         | Family First Party - VIC                                                           | $170,000        |
+| ALP                                         | Australian Labour Party                                                            | $164,594        |
+| Shooters                                    | Australian Fishing and Lifestyle Party                                             | $163,255        |
+| GLazarus                                    | GLT                                                                                | $160,317        |
+| LIB                                         | Liberal Party of Australia (SA Division) / LIB-SA                                  | $160,000        |
+| ALP                                         | ALP-NT                                                                             | $159,050        |
+| NP                                          | National Party of Aust - NSW                                                       | $155,310        |
+| CLP                                         | Country Liberal Party (NT)                                                         | $154,900        |
+| CEC                                         | CEC-Fed                                                                            | $154,411        |
+| ALP                                         | ALP- Australian Labor Party                                                        | $152,000        |
+| Brisbane                                    | The Brisbane's Future Committee                                                    | $151,500        |
+| LIB                                         | Liberal Party LIB-NSW                                                              | $150,750        |
+| DEM                                         | Australian Democrats, Western Australian Division - WA                             | $150,367        |
+| LIB                                         | LIB - Liberal Party of Australia                                                   | $150,000        |
+| LIB                                         | Liberal Party of Australia (W.A. Division)                                         | $150,000        |
+| LIB                                         | Liberal Party of Australia (Victorian Division) / LIB-VIC                          | $149,341        |
+| GRN                                         | GRN-NSW                                                                            | $148,426        |
+| ALP                                         | ALP - VIC                                                                          | $148,298        |
+| LIB                                         | The 500 Club (VIC)                                                                 | $147,407        |
+| ALP                                         | ALP - FED                                                                          | $141,665        |
+| ALP                                         | ALP-TAS                                                                            | $140,842        |
+| ALP                                         | Australian Labor Party - NSW Branch                                                | $140,653        |
+| DEM                                         | Australian Democrats - National Executive                                          | $137,616        |
+| DLP                                         | Democratic Labor Party (DLP) of Australia - NATIONAL                               | $134,000        |
+| ALP                                         | Australian Labor Party Victorian Branch                                            | $132,967        |
+| LIB                                         | The 500 Club (WA)                                                                  | $132,547        |
+| LIB                                         | LIB NSW                                                                            | $131,329        |
+| Climate                                     | Climate Change Coalition                                                           | $130,519        |
+| ALP                                         | Australian Labor Party (TAS Branch)                                                | $129,852        |
+| Christ                                      | Australian Conservatives (Qld)                                                     | $125,000        |
+| NP                                          | National Party                                                                     | $124,166        |
+| GetUp                                       | Get Up                                                                             | $123,245        |
+| ALP                                         | Australian Labor Party (ALP) / ALP-FED                                             | $122,800        |
+| GRN                                         | The Greens NSW - NATIONAL                                                          | $122,560        |
+| ALP                                         | Progressive Business                                                               | $121,441        |
+| RiseUp                                      | Rise Up Australia Party                                                            | $121,100        |
+| PHON                                        | Pauline Hanson's One Nation                                                        | $119,338        |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) NSW                                   | $117,120        |
+| GRN                                         | Australian Greens, Australian Capital Territory Branch                             | $115,536        |
+| ALP                                         | Australian Labor Party (SA Branch) ALP-SA                                          | $115,126        |
+| LIB                                         | Liberal Party of Australia LIB FED                                                 | $114,000        |
+| LIB                                         | Liberal Party of Aust.                                                             | $110,000        |
+| LIB                                         | The Menzies Research Centre Limited                                                | $103,000        |
+| LIB                                         | Liberal Party of Australia (WA Div)                                                | $102,000        |
+| LIB                                         | Liberal National Party/LNP-QLD                                                     | $100,500        |
+| ALP                                         | ALP NSW (Federal Campaign)                                                         | $100,000        |
+| ALP                                         | ALP-FED (Hughes)                                                                   | $100,000        |
+| DLP                                         | DLP-VIC                                                                            | $100,000        |
+| Euthanasia                                  | Voluntary Euthanasia Party                                                         | $100,000        |
+| GRN                                         | Australian Greens Victorian Branch                                                 | $100,000        |
+| LIB                                         | Advanced Australia                                                                 | $100,000        |
+| LIB                                         | LIB- FED                                                                           | $100,000        |
+| LIB                                         | LIB-ACT- Federal Secretariat                                                       | $100,000        |
+| LIB                                         | Liberal Party of Australia (LIB-ACT)                                               | $100,000        |
+| LIB                                         | LPA-NSW                                                                            | $100,000        |
+| LIB                                         | The Free Enterprise Foundation / LIB                                               | $100,000        |
+| XEN                                         | (NXT) XEN                                                                          | $100,000        |
+| XEN                                         | XEN                                                                                | $100,000        |
+| AEQ                                         | Australian Equality Party (Marriage)                                               | $99,999         |
+| ALP                                         | ALP National Secretariat - ALP                                                     | $99,716         |
+| GRN                                         | Queensland Greens - NATIONAL                                                       | $98,711         |
+| PHON                                        | Pauline Hansons One Nation QLD Division                                            | $98,175         |
+| DLP                                         | Democratic Labour Party - Victorian Branch                                         | $98,130         |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) - WA                                  | $96,200         |
+| ALP                                         | SA Progressive Business Incorporated                                               | $95,238         |
+| LIB                                         | LIBERAL NATIONAL PARTY                                                             | $93,283         |
+| LIB                                         | Liberal Party of Australia (VIC Division) (paid to Enterprise Victoria)            | $92,000         |
+| GetUp                                       | GetUp                                                                              | $91,720         |
+| LIB                                         | Liberal Party                                                                      | $90,829         |
+| Christ                                      | Australian Conservatives (Vic)                                                     | $90,826         |
+| LDP                                         | Liberal Democratic Party (LDP)                                                     | $90,000         |
+| ZSteggall                                   | Warringah Independent Ltd                                                          | $90,000         |
+| LIB                                         | Liberal Party of Australia (SA) LIB-SA                                             | $88,127         |
+| LIB                                         | Lib-Fed                                                                            | $85,475         |
+| LIB                                         | Liberal Party of Australia - VIC Branch                                            | $84,592         |
+| LIB                                         | Liberal Party of Australia LIB-VIC                                                 | $82,663         |
+| ALP                                         | Australian Labor Party - NSW                                                       | $80,252         |
+| ALP                                         | Australia Labor Party (ALP)                                                        | $80,000         |
+| GetUp                                       | Getup Ltd                                                                          | $80,000         |
+| LIB                                         | LIBERAL NATIONAL PARTY (LNP)                                                       | $80,000         |
+| LIB                                         | Liberal Party of Australia - LIB VIC                                               | $80,000         |
+| LIB                                         | Liberal Party of Australia (LIB)                                                   | $80,000         |
+| Christ                                      | Australian Conservatives                                                           | $77,600         |
+| LIB                                         | Liberal Party of Australia (WA Div) Inc - LIB-WA                                   | $76,000         |
+| ALP                                         | Australian Labor Party (ALP) / ALP                                                 | $75,900         |
+| JLambie                                     | Jacqui Lambie Network                                                              | $75,700         |
+| Christ                                      | Australian Conservatives (NSW)                                                     | $75,000         |
+| KAP                                         | KATTER'S AUSTRALIAN PARTY / KAP                                                    | $75,000         |
+| LIB                                         | Advance Aus Limited                                                                | $75,000         |
+| Shooters                                    | Australian Recreational Fishers Party                                              | $75,000         |
+| Hope                                        | Hope Party Australia                                                               | $74,898         |
+| LIB                                         | Liberal Party of Australia - NSW - LIB NSW                                         | $74,000         |
+| SA                                          | Socialist Alliance                                                                 | $73,700         |
+| ALP                                         | Country Labor Party                                                                | $73,664         |
+| ALP                                         | McKell Foundation Inc                                                              | $73,333         |
+| ALP                                         | Australian Labor Party - VIC Branch                                                | $73,042         |
+| ALP                                         | Australian Labor Party - ALP-FED                                                   | $72,920         |
+| LIB                                         | Liberal Party of Australia NSW                                                     | $71,568         |
+| GRN                                         | The Australian Greens - Victoria - NATIONAL                                        | $70,573         |
+| LIB                                         | Liberal Party of Australia (NSW) Division                                          | $70,272         |
+| LIB                                         | Liberal Party of Australia/LIB-NSW                                                 | $70,050         |
+| LIB                                         | LIB FED                                                                            | $70,000         |
+| LIB                                         | Liberal Party of Australia LIB - FED                                               | $70,000         |
+| ALP                                         | ALP NATIONAL SECRETARIAT ALP-FED                                                   | $69,500         |
+| LIB                                         | Liberal Party of Australia (SA Division) LIB-SA                                    | $69,471         |
+| ALP                                         | ALP-ACT - National Secretariat                                                     | $69,000         |
+| Shooters                                    | Shooters, Fishers and Farmers Party                                                | $68,700         |
+| LIB                                         | Liberal Party of Austtralia, NSW Division LIB-NSW                                  | $68,210         |
+| ALP                                         | Australian Labor Party (Queensland)                                                | $68,144         |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) - NATIONAL                            | $67,721         |
+| PHON                                        | Pauline Hanson's One Nation QLD Division                                           | $67,720         |
+| ZSteggall                                   | Warringah Independents                                                             | $67,000         |
+| ALP                                         | Australian Labor Party National Secretariat                                        | $66,000         |
+| LIB                                         | Liberal National Party of Queensland / LNP-QLD                                     | $65,970         |
+| ALP                                         | ALP-NAT                                                                            | $65,735         |
+| LIB                                         | 250 Club Limited                                                                   | $65,296         |
+| ALP                                         | ALP -NSW                                                                           | $65,000         |
+| LIB                                         | Liberal National Party (LNP-QLD)                                                   | $65,000         |
+| LIB                                         | Liberal Party of Australia - VIC                                                   | $65,000         |
+| WA Party                                    | WESTERN AUSTRALIA PARTY                                                            | $65,000         |
+| ALP                                         | ALP-FED Federal Labor Business Forum                                               | $64,800         |
+| LIB                                         | LNP - QLD                                                                          | $64,791         |
+| LIB                                         | Liberal Party of Australia (Victorian Division) - LIB-VIC                          | $64,640         |
+| LIB                                         | Liberal Party NSW Division                                                         | $64,571         |
+| ALP                                         | Australian Labor Party - SA Branch                                                 | $64,566         |
+| ALP                                         | Australian Labor Party - VIC                                                       | $62,830         |
+| LIB                                         | LIBERAL PARTY OF AUSTRALIA                                                         | $62,000         |
+| LIB                                         | LNP Queensland                                                                     | $61,200         |
+| ALP                                         | ALP-WA Australian Labor Party (Western Australian Branch)                          | $61,000         |
+| LIB                                         | Liberal Party of Australia (Tas Div)                                               | $60,959         |
+| LIB                                         | LIB - VIC                                                                          | $60,667         |
+| LIB                                         | LIB-ACT                                                                            | $60,118         |
+| Christ                                      | Australian Christians - ACH                                                        | $60,000         |
+| LIB                                         | Canberra Liberals (LIB-ACT)                                                        | $60,000         |
+| LIB                                         | Liberal Foundation Inc                                                             | $60,000         |
+| LIB                                         | Liberal Party of Aust LIB-FED                                                      | $60,000         |
+| Sus                                         | SPP-FED                                                                            | $60,000         |
+| LIB                                         | Liberal Party of Australia SA LIB-SA                                               | $59,202         |
+| CEC                                         | CEC Australia (Services) Pty Ltd                                                   | $58,950         |
+| ALP                                         | Australian Labor Party SA ALP-SA                                                   | $58,784         |
+| ALP                                         | Australian Labor Party (ALP-FED)                                                   | $57,491         |
+| ChristDem                                   | Christian Democratic Party - WA                                                    | $57,000         |
+| LIB                                         | Liberal Party of Aust Lib - Fed                                                    | $57,000         |
+| ZSteggall                                   | warringah independent pty ltd                                                      | $57,000         |
+| ZSteggall                                   | Warringah Independents Pty Ltd                                                     | $57,000         |
+| ALP                                         | ALP National Secretariat/ALP-FED                                                   | $56,700         |
+| ALP                                         | ALP - National Secretariat (ALP-FED)                                               | $56,158         |
+| ALP                                         | ALP National Secretariat - ALP-FED                                                 | $56,000         |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) WA Branch                             | $55,500         |
+| LIB                                         | Liberal Party of Australia (LIB/FED)                                               | $55,052         |
+| GRN                                         | Australian Greens - ACT                                                            | $55,024         |
+| LIB                                         | Liberal Party of Australia Lib-Fed                                                 | $55,000         |
+| ALP                                         | Australian Labor Party - QLD /ALP-QLD                                              | $54,250         |
+| ALP                                         | ALP - National Secretariat Business Forum                                          | $54,000         |
+| ALP                                         | Australian Labor Party (NT Branch)                                                 | $54,000         |
+| Sus                                         | SPP                                                                                | $54,000         |
+| ALP                                         | ALP QLD                                                                            | $53,740         |
+| ALP                                         | ALP-National Secretariat                                                           | $53,525         |
+| LIB                                         | Liberal Party of Australia/LIB-TAS                                                 | $53,270         |
+| LIB                                         | LIB-VIC Liberal Party of Australia (Vic Division)                                  | $53,115         |
+| ALP                                         | Australian Labor Party                                                             | $52,900         |
+| LIB                                         | LIB Liberal Party of Australia                                                     | $52,250         |
+| LIB                                         | Liberal Party of Aust NSW                                                          | $52,160         |
+| GetUp                                       | GETUP LTD                                                                          | $52,000         |
+| LIB                                         | Liberal Party of Australia, NSW Division / LIB-NSW                                 | $51,677         |
+| LIB                                         | LIB - SA                                                                           | $51,119         |
+| LDP                                         | Liberal Democratic Party (QLD Branch)                                              | $50,990         |
+| ALP                                         | Australian Labor Party (QLD Branch)                                                | $50,400         |
+| ALP                                         | Australian Labor Party (State of Queensland) / ALP-QLD                             | $50,268         |
+| NP                                          | NAT-WA National Party of Australia (WA) Inc                                        | $50,250         |
+| RPA                                         | Republican Party of Australia                                                      | $50,200         |
+| LIB                                         | Liberal Party of Australia (SA Branch)                                             | $50,175         |
+| ALP                                         | ALP - Macquarie (Susan Templeman)(ALP-NSW)                                         | $50,000         |
+| ALP                                         | ALP NT                                                                             | $50,000         |
+| CLP                                         | CLP NT                                                                             | $50,000         |
+| FNPP                                        | Australia's First Nations Political Party (FNP)                                    | $50,000         |
+| GetUp                                       | Get Up Ltd                                                                         | $50,000         |
+| LIB                                         | Advance Australia Ltd                                                              | $50,000         |
+| LIB                                         | LIB Party of Australia (QLD Division)                                              | $50,000         |
+| LIB                                         | Liberal Party of Aust - LIB-FED                                                    | $50,000         |
+| LIB                                         | Liberal Party of Australia - Brian Loughnane                                       | $50,000         |
+| LIB                                         | Liberal Party of Australia (Victorian Division) LIB-VIC                            | $50,000         |
+| LIB                                         | Liberal Party of Australia (wa Division) Inc                                       | $50,000         |
+| LIB                                         | Liberal Party of Australia NSW Division (LIB-NSW)                                  | $50,000         |
+| LIB                                         | Mr Bruce McIver, LNP Federal Campaign                                              | $50,000         |
+| LIB                                         | The Liberal Party of Australia (WA Division)                                       | $50,000         |
+| NP                                          | National (NSW)                                                                     | $50,000         |
+| NP                                          | Nationals - NAT-FED                                                                | $50,000         |
+| NP                                          | NSW Nationals - NAT-NSW                                                            | $50,000         |
+| ALP                                         | Labour Movement Work Experience Program                                            | $49,857         |
+| GRN                                         | Australian Greens - Victoria                                                       | $49,685         |
+| ALP                                         | Progressive Business Association - VIC Branch                                      | $49,332         |
+| LIB                                         | Liberal Party of Australia VIC                                                     | $49,118         |
+| NP                                          | National Party of Australia - Victoria (NAT-VIC)                                   | $48,900         |
+| ALP                                         | ALP Progressive Business (SA)                                                      | $48,272         |
+| PHON                                        | One Nation Queensland Division                                                     | $48,000         |
+| ALP                                         | Progressive Business Association ALP-VIC                                           | $47,390         |
+| ALP                                         | Australian Labor Party (South Australian Branch) ALP-SA                            | $46,774         |
+| LIB                                         | LIB-VIC Liberal Party of Australia (Victoria Division)                             | $46,765         |
+| LIB                                         | Liberal Party of Aust, NSW Division                                                | $46,070         |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) Natio                                 | $45,587         |
+| ALP                                         | Australian Labor Party ALP-FED                                                     | $45,296         |
+| CLP                                         | CLPNT                                                                              | $45,000         |
+| LIB                                         | Liberal Party Manly SEC                                                            | $45,000         |
+| LIB                                         | Liberal Party of Australia / LIB-WA                                                | $45,000         |
+| LIB                                         | Liberal Party of WA                                                                | $44,975         |
+| PHON                                        | One Nation Western Australia - WA                                                  | $44,624         |
+| LIB                                         | Liberal Party of Australia Federal Forum/LIB-NSW                                   | $44,000         |
+| NP                                          | National Party of NSW                                                              | $44,000         |
+| LIB                                         | LIberal Party of Australia (WA)                                                    | $43,950         |
+| ALP                                         | Australian Labor Party/ALP-FED                                                     | $43,000         |
+| LIB                                         | 250 Club Ltd                                                                       | $42,900         |
+| Climate                                     | Independents For Climate Action Now                                                | $42,000         |
+| LIB                                         | Menzies 200 Club                                                                   | $41,785         |
+| LIB                                         | Liberal Party of Australia (Vic Division)                                          | $41,500         |
+| UAP                                         | Unity - Say NoTo Hanson                                                            | $41,000         |
+| LIB                                         | Liberal Party of Australia (LIB)                                                   | $40,893         |
+| LIB                                         | Liberal Party of Australia - SA LIB-SA                                             | $40,672         |
+| ALP                                         | ALP-Federal                                                                        | $40,450         |
+| NP                                          | NPA Nominees Pty Ltd                                                               | $40,116         |
+| LIB                                         | Liberal Party of NSW                                                               | $40,067         |
+| ALP                                         | ALP Federal Secretariat                                                            | $40,000         |
+| CLP                                         | CLP                                                                                | $40,000         |
+| GetUp                                       | GET UP LIMITED                                                                     | $40,000         |
+| LIB                                         | LNP - Whitsunday                                                                   | $40,000         |
+| LIB                                         | LPA - NSW (Federal Campaign)                                                       | $40,000         |
+| LIB                                         | The Liberal Party of Australia / LIB-FED                                           | $40,000         |
+| Sus                                         | SUSTAINABLE AUSTRALIA - STOP OVERDEVELOPMENT. STOP CORRUPTION.                     | $40,000         |
+| ALP                                         | Australian Labor Party - SA ALP-SA                                                 | $39,795         |
+| ACCI                                        | Australia Chamber of Commerce and Industry                                         | $39,600         |
+| NP                                          | NAT - NSW                                                                          | $39,280         |
+| PHON                                        | New Country Party - NATIONAL                                                       | $39,279         |
+| LIB                                         | Enterprise Victoria (LIB-VIC)                                                      | $39,100         |
+| LIB                                         | Liberal National Party of Queensland/LNP-QLD                                       | $39,008         |
+| LIB                                         | Libs-NSW                                                                           | $38,750         |
+| LIB                                         | Liberal Party of Australia LIB-NSW                                                 | $38,727         |
+| LIB                                         | Liberal Party of Australia - TAS                                                   | $38,550         |
+| LIB                                         | Liberal Party of Australia - LIB-TAS                                               | $38,200         |
+| ALP                                         | Australia Labor Party (State of Queensland) / ALP-QLD                              | $38,000         |
+| LIB                                         | Liberal National Party of Qld                                                      | $38,000         |
+| ALP                                         | ALP - WA                                                                           | $37,879         |
+| ZSteggall                                   | Warringah Independant Limited                                                      | $37,631         |
+| ALP                                         | ALP - Fed                                                                          | $37,600         |
+| LIB                                         | Liberal Party of Australia (SA Div)                                                | $37,272         |
+| LIB                                         | Liberal Party NSW Federal Campaign Account - LIB-NSW                               | $37,100         |
+| ALP                                         | Aust Labor Party (SA Branch)/ALP-SA                                                | $37,060         |
+| HMP                                         | Help End Marijuana Prohibition (HEMP) Party                                        | $37,000         |
+| DEM                                         | Australian Democrats Victorian Division - VIC                                      | $36,993         |
+| LIB                                         | LIB-VIC (Enterprise 500)                                                           | $36,500         |
+| ALP                                         | Australian Labour Party (VIC Branch)                                               | $36,372         |
+| ALP                                         | Australian Labor Party (ALP) ALP-FED                                               | $36,200         |
+| GRN                                         | Greens NSW                                                                         | $35,880         |
+| ALP                                         | ALP-NSW Australian Labor Party (NSW Branch)                                        | $35,700         |
+| ALP                                         | Australian Labor Party / ALP                                                       | $35,600         |
+| ALP                                         | Australian Labor Party of Qld                                                      | $35,000         |
+| LIB                                         | Liberal Party of Aust Lib - NSW                                                    | $35,000         |
+| LIB                                         | Liberal Party of Aust LIB-NSW                                                      | $35,000         |
+| UAP                                         | Unity - Say No To Hanson - NATIONAL                                                | $34,925         |
+| ALP                                         | ALP-FED Australian Labor Party (ALP)                                               | $34,500         |
+| ALP                                         | Australia Labor Party (ALP)                                                        | $34,500         |
+| LIB                                         | Liberal Party of Australia/LIB                                                     | $34,288         |
+| ALP                                         | Australian Labor Party (ALP) - National Secretariat                                | $33,800         |
+| ALP                                         | Australian Labor Party (Western Australia Branch)                                  | $33,750         |
+| DEM                                         | Australian Democrats - SA Division Inc                                             | $33,722         |
+| LIB                                         | Liberal National Party QLD                                                         | $33,686         |
+| LIB                                         | LIB - Vic                                                                          | $33,604         |
+| LIB                                         | Liberal Party of Australia, NSW Division / LIB NSW                                 | $33,326         |
+| LIB                                         | LNP - FDC                                                                          | $33,000         |
+| LIB                                         | North Sydney Forum - LIB-NSW                                                       | $33,000         |
+| ALP                                         | Australian Labor Party (Victorian Branch) / ALP-VIC                                | $32,200         |
+| LIB                                         | Lib-Federal                                                                        | $32,075         |
+| LIB                                         | LNP/LNP-QLD                                                                        | $32,010         |
+| GRN                                         | GRN-WA                                                                             | $32,000         |
+| DLP                                         | Democratic Labor Party (DLP) - Victorian Branch                                    | $31,267         |
+| ALP                                         | Australian Labor Party (N.S.W Branch) ALP-NSW                                      | $31,100         |
+| ALP                                         | ALP National Secretariat/ALP - FED                                                 | $31,000         |
+| CLP                                         | COUNTRY LIBERAL PARTY (NT)                                                         | $31,000         |
+| NP                                          | National Party of Australia Federal Campaign - NAT-NSW                             | $30,700         |
+| LIB                                         | Liberal Party - LIB - NSW                                                          | $30,480         |
+| ALP                                         | ALP NSW BANKS CAMPAIGN                                                             | $30,000         |
+| ALP                                         | ALP QLD - Dawson (Mike Brunker)                                                    | $30,000         |
+| ALP                                         | ALP QLD - Flynn (Chris Trevor)                                                     | $30,000         |
+| ALP                                         | ALP-FED (Cook)                                                                     | $30,000         |
+| ALP                                         | ALP-SA Australian Labor Party (South Australian Branch)                            | $30,000         |
+| ALP                                         | Australian Labor Party NSW Branch Watson Federal Campaign A/C ALP-NSW              | $30,000         |
+| ALP                                         | Labor Business Dialogue                                                            | $30,000         |
+| CEC                                         | ACP-VIC                                                                            | $30,000         |
+| Fed                                         | Country Alliance                                                                   | $30,000         |
+| LIB                                         | Altum LNP-QLD                                                                      | $30,000         |
+| LIB                                         | Lib - SA                                                                           | $30,000         |
+| LIB                                         | LIB (Enterprise 500 Victoria)                                                      | $30,000         |
+| LIB                                         | The Liberal Party of Australia Victorian Division                                  | $30,000         |
+| NP                                          | NATIONAL PARTY OF AUSTRALIA (NAT - FED)                                            | $30,000         |
+| LIB                                         | LIB TAS                                                                            | $29,761         |
+| LIB                                         | LIB-NSW - Millennium Forum of New South Wales Federal Account                      | $29,600         |
+| LIB                                         | Lib - NSW                                                                          | $29,465         |
+| ALP                                         | Australian Labor Party - ALP - FED                                                 | $29,266         |
+| LIB                                         | LIB - VIC (Higgins 200 Club)                                                       | $28,700         |
+| ALP                                         | ALP - TAS                                                                          | $28,540         |
+| LIB                                         | Liberal National Party LNP-QLD                                                     | $28,034         |
+| GRN                                         | GRN-VIC                                                                            | $28,000         |
+| DEM                                         | Australian Democrats Queensland Division                                           | $27,600         |
+| ALP                                         | Federal Labor Business Forum (ALP-NAT)                                             | $27,500         |
+| LIB                                         | Australian Business Network (LIB-FED)                                              | $27,500         |
+| LIB                                         | LIB (Higgins 200 Club)                                                             | $27,500         |
+| LIB                                         | LIB-VIC (Higgins 200 Club)                                                         | $27,500         |
+| LIB                                         | Lib-Vic (Higgins 200 Club)                                                         | $27,500         |
+| LIB                                         | Millenium Forum - NSW-EFT                                                          | $27,500         |
+| NP                                          | Nationa Party of Australia/NAT-FED                                                 | $27,500         |
+| ALP                                         | ALP Progressive Business (VIC)                                                     | $27,398         |
+| LIB                                         | Liberal Party of Australia, NSW Division - LIB-NSW                                 | $27,380         |
+| LIB                                         | Secondment - LIB-FED                                                               | $27,379         |
+| LIB                                         | Liberal Party of Australia (W.A Division) Inc                                      | $27,370         |
+| NP                                          | National Party of Australia (WA) Inc (NAT-WA)                                      | $27,200         |
+| Harradine                                   | Tasmanian Independent Senator Brian Harradine Grou                                 | $27,000         |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) - NSW                                 | $26,928         |
+| PHON                                        | Pauline Hanson's One Nation - QLD                                                  | $26,875         |
+| LIB                                         | Liberal Party (W.A. Division) Inc. / LIB-WA                                        | $26,809         |
+| LIB                                         | The Pinnacle Club - Liberal Party of Australia (Victorian Division)                | $26,700         |
+| LDP                                         | Liberal Democratic Party (Victoria Branch)                                         | $26,670         |
+| LIB                                         | Liberal Party of Australia LIB - TAS                                               | $26,563         |
+| LIB                                         | Liberal Party of Australia ACT                                                     | $26,548         |
+| LIB                                         | LIBERAL PARTY - FEDERAL - LIB-FED                                                  | $26,500         |
+| NP                                          | National Party of Australia / NAT-FED                                              | $26,500         |
+| LIB                                         | Liberal Party of Australia - VIC Division                                          | $26,200         |
+| LIB                                         | Liberal Party of Victoria                                                          | $26,181         |
+| ALP                                         | Australian Labor Party (Victorian Branch) ALP-VIC                                  | $26,167         |
+| ALP                                         | Australian Labor Party (QLD)                                                       | $26,000         |
+| LIB                                         | Liberal Party LIB-ACT                                                              | $26,000         |
+| LIB                                         | The Liberal Party of Australia (Victorian Division) / LIB-VIC                      | $26,000         |
+| LIB                                         | 500 Club of New South Wales Inc                                                    | $25,992         |
+| Housing                                     | Australian Affordable Housing Party                                                | $25,919         |
+| LIB                                         | Liberal Party of Australia LIB NSW                                                 | $25,500         |
+| LIB                                         | LIB-VIC Liberal Party of Australia (Victorian Division)                            | $25,330         |
+| ALP                                         | Australian Labor Party (ALP) - ALP                                                 | $25,250         |
+| ZSteggall                                   | Warringah Independent Limited                                                      | $25,250         |
+| LIB                                         | Liberal Party of Australia - Tasmanian Division / LIB-TAS                          | $25,200         |
+| ALP                                         | ALP - Business Forum ALP Federal                                                   | $25,000         |
+| ALP                                         | ALP - National Secretariat                                                         | $25,000         |
+| ALP                                         | ALP-VIC - Chisholm FEA                                                             | $25,000         |
+| ALP                                         | The Australian Labor Party (Victorian Branch)                                      | $25,000         |
+| CLP                                         | The Free Enterprise Foundation - CLP-NT - Country Liberals                         | $25,000         |
+| Forum of WA                                 | The Leaders' Forum of Western Australia                                            | $25,000         |
+| KPhelps                                     | KP Independents Limited                                                            | $25,000         |
+| LIB                                         | Enterprise 500 Victoria                                                            | $25,000         |
+| LIB                                         | Federal Liberal Party                                                              | $25,000         |
+| LIB                                         | Free Enterprise Foundation LIB-FED                                                 | $25,000         |
+| LIB                                         | Lib - WA                                                                           | $25,000         |
+| LIB                                         | LIB Party of Australia (NSW Division)                                              | $25,000         |
+| LIB                                         | LIB-WA Liberal Party (WA Division Inc)                                             | $25,000         |
+| LIB                                         | Liberal - Curtin Liberal Federal Campaign (WA)                                     | $25,000         |
+| LIB                                         | Liberal National Party of Queensland (Lord Mayor Community Trust)                  | $25,000         |
+| LIB                                         | Liberal Party (Vic Div.)                                                           | $25,000         |
+| LIB                                         | Liberal Party (WA Division) Inc./LIB-WA                                            | $25,000         |
+| LIB                                         | Liberal Party of Australia - Tasmania                                              | $25,000         |
+| LIB                                         | Liberal Party of Australia (WA Division) Inc/LIB-WA                                | $25,000         |
+| LIB                                         | Liberal Party of Australia, NSW Division (Federal account)                         | $25,000         |
+| LIB                                         | Liberal Party of Australia, NSW Division, Mitchell FEC                             | $25,000         |
+| LIB                                         | Liberal Party Warringah FEC                                                        | $25,000         |
+| LIB                                         | LNP QUEENSLAND                                                                     | $25,000         |
+| LIB                                         | Menzies Research Centre                                                            | $25,000         |
+| LIB                                         | Menzies Research Centre Ltd                                                        | $25,000         |
+| LIB                                         | Team 200 Club (assoc with Liberal VIC)                                             | $25,000         |
+| LIB                                         | The Liberal Party of Australia (SA Division)                                       | $25,000         |
+| LIB                                         | Warringah FEC                                                                      | $25,000         |
+| Shooters                                    | AFLP. Aust Fishing & Lifestyle Party                                               | $25,000         |
+| UAP                                         | UNP                                                                                | $24,600         |
+| ALP                                         | Australian Labor Party (Northern Territory Branch)                                 | $24,595         |
+| ALP                                         | Progressive Business Association / ALP-VIC                                         | $24,469         |
+| ALP                                         | Australian Labor Party - ALP                                                       | $24,460         |
+| GRN                                         | Australian Greens - SA                                                             | $24,450         |
+| LIB                                         | (LNP) Lord Mayors 'Go Forward'                                                     | $24,000         |
+| LIB                                         | Liberal National Party (LNP)                                                       | $24,000         |
+| LIB                                         | LNP/BCC Office Space                                                               | $24,000         |
+| LIB                                         | North Sydney Forum/LIB-FED                                                         | $24,000         |
+| ALP                                         | Progressive Business Association/ALP-VIC                                           | $23,600         |
+| ALP                                         | ALP - Australian Labor Party                                                       | $23,100         |
+| LIB                                         | The 500 Club (LIB-WA)                                                              | $23,000         |
+| ALP                                         | Blacktown                                                                          | $22,871         |
+| LIB                                         | Liberal Party of Australia - NSW Division (LIB-NSW)                                | $22,795         |
+| ALP                                         | Australian Labor Party - Federal Business Forum                                    | $22,727         |
+| LIB                                         | Liberal Party of Australia, NSW Divison / LIB-NSW                                  | $22,545         |
+| ALP                                         | Australian Labor Party (Federal Branch)                                            | $22,500         |
+| LIB                                         | LIB-VIC (Enterprise 500 Victoria)                                                  | $22,500         |
+| LIB                                         | Liberal National Party of Queensland/ LNP-QLD                                      | $22,500         |
+| LIB                                         | Liberal Party LIB                                                                  | $22,500         |
+| NP                                          | Nationals (WA)                                                                     | $22,331         |
+| LIB                                         | Millenium Forum                                                                    | $22,310         |
+| LIB                                         | Liberal Party of Tasmania - Tasmanian Division / LIB-TAS                           | $22,200         |
+| ALP                                         | ALP-Fed                                                                            | $22,000         |
+| ALP                                         | Australian Labor Party (NSW) Branch                                                | $22,000         |
+| ALP                                         | Australian Labor Party NSW Branch Business Member                                  | $22,000         |
+| LIB                                         | LIB - Menzies Research Centre                                                      | $22,000         |
+| LIB                                         | Liberal Party of Australia - LIB-NSW (Federal Account)                             | $22,000         |
+| LIB                                         | Peninsular Independent Ltd                                                         | $22,000         |
+| NP                                          | John McEwen House Pty Ltd                                                          | $22,000         |
+| LIB                                         | Liberal Party of Australia (WA Division)                                           | $21,895         |
+| NP                                          | National Party NSW                                                                 | $21,745         |
+| LIB                                         | Liberal Party Avalon                                                               | $21,680         |
+| ALP                                         | ALP-VIC Progressive Business                                                       | $21,670         |
+| ALP                                         | Australian Labor Party Queensland                                                  | $21,500         |
+| GLazarus                                    | Glenn Lazarus Team                                                                 | $21,220         |
+| ALP                                         | Progressive Business Association - SA Branch                                       | $21,185         |
+| GRN                                         | Tasmanian Greens - NATIONAL                                                        | $21,107         |
+| Shooters                                    | Shooters and Fishers Party Inc.                                                    | $21,050         |
+| ALP                                         | ALP-Queensland                                                                     | $21,000         |
+| ALP                                         | Australian Labor Party NSW Branch                                                  | $21,000         |
+| PHON                                        | Pauline Hanson's One Nation - NATIONAL                                             | $20,990         |
+| ALP                                         | Australian Labor Party (SA Branch) ALP-SA                                          | $20,780         |
+| GRN                                         | The ACT Greens                                                                     | $20,729         |
+| PHON                                        | One Nation Queensland Division - QLD                                               | $20,650         |
+| CLP                                         | NT CLP                                                                             | $20,500         |
+| Sus                                         | Sustainable Australia Party - Stop Overdevelopment / Corruption                    | $20,500         |
+| LIB                                         | Liberal Party NSW                                                                  | $20,325         |
+| LIB                                         | Liberal Party of Australia (Federal Office)                                        | $20,320         |
+| ALP                                         | ALP-VIC Progressive Business Association                                           | $20,150         |
+| ALP                                         | ALP - Charlton (Greg Combet)(ALP-NSW)                                              | $20,000         |
+| ALP                                         | ALP - Chifley Research Centre                                                      | $20,000         |
+| ALP                                         | ALP (NSW Branch) McMahon FCA - ALP-NSW                                             | $20,000         |
+| ALP                                         | ALP Eden-Monaro Federal Campaign Account/ALP-NSW                                   | $20,000         |
+| ALP                                         | ALP Melbourne (Cath Bowtell)(ALP-VIC)                                              | $20,000         |
+| ALP                                         | ALP NSW Division                                                                   | $20,000         |
+| ALP                                         | ALP WA -Canning (Alannah McTiernan)                                                | $20,000         |
+| ALP                                         | ALP-FED/Chifley Research Centre                                                    | $20,000         |
+| ALP                                         | ALP-NSW (Rockdale ALP Campaign)                                                    | $20,000         |
+| ALP                                         | ALP-QLD - Dawson (Mike Brunker)                                                    | $20,000         |
+| ALP                                         | ALP-VIC (Hotham)                                                                   | $20,000         |
+| ALP                                         | Australian Labor Party - 2010 Election Campaign                                    | $20,000         |
+| ALP                                         | Australian Labor Party (Victorian Branch) (paid to ALP Isaacs)                     | $20,000         |
+| ALP                                         | Australian Labor Party NT                                                          | $20,000         |
+| ALP                                         | Australian Labor Party QLD                                                         | $20,000         |
+| ALP                                         | Lilley Campaign ALP QLD                                                            | $20,000         |
+| ALP                                         | Mark Dreyfus QC MP ALP-ISAACS                                                      | $20,000         |
+| Cherish Life                                | Cherish Life Queensland Inc                                                        | $20,000         |
+| CLP                                         | NT Country Liberal Party                                                           | $20,000         |
+| DEM                                         | Australian Democrats - NSW Division                                                | $20,000         |
+| GetUp                                       | getup                                                                              | $20,000         |
+| GRN                                         | Australian Greens GRN                                                              | $20,000         |
+| GRN                                         | GRN - ACT                                                                          | $20,000         |
+| GRN                                         | NSW GREENS                                                                         | $20,000         |
+| GRN                                         | The Australian Greens - Victoria / GRN-VIC                                         | $20,000         |
+| LIB                                         | Forward Brisbane Leadership (LNP QLD)                                              | $20,000         |
+| LIB                                         | Dawn Fardell MP - Liberal Party                                                    | $20,000         |
+| LIB                                         | Lib                                                                                | $20,000         |
+| LIB                                         | LIB / Liberal Party of Australia                                                   | $20,000         |
+| LIB                                         | Lib- SA                                                                            | $20,000         |
+| LIB                                         | LIB-FED Liberal National Party                                                     | $20,000         |
+| LIB                                         | LIB-FED/Menzies Research Centre                                                    | $20,000         |
+| LIB                                         | LIB-WA Liberal Party (W.A. Division) Inc                                           | $20,000         |
+| LIB                                         | LIB/Liberal Party of Australia                                                     | $20,000         |
+| LIB                                         | Liberal National Party / LNP-QLD                                                   | $20,000         |
+| LIB                                         | LIBERAL PARTY LIB-ACT                                                              | $20,000         |
+| LIB                                         | Liberal Party NSW Reid Federal Campaign - LIB-NSW                                  | $20,000         |
+| LIB                                         | Liberal Party of Aust - TAS                                                        | $20,000         |
+| LIB                                         | Liberal Party of Australia - 2010 Election Campaign                                | $20,000         |
+| LIB                                         | Liberal Party of Australia LIB - VIC                                               | $20,000         |
+| LIB                                         | Liberal Party of Australia NSW Branch LIB-NSW                                      | $20,000         |
+| LIB                                         | Liberal Party Wannon (LIB-VIC)                                                     | $20,000         |
+| LIB                                         | LPA (WA Division) - LIB-WA                                                         | $20,000         |
+| LIB                                         | Menzies Research Centre LIB-FED                                                    | $20,000         |
+| LIB                                         | Millennium Forum - Liberal Party of Australia NSW Division                         | $20,000         |
+| LIB                                         | The Liberal Party of Australia - Federal Secretariat                               | $20,000         |
+| NP                                          | National Party Lowan Electorate (NAT-VIC)                                          | $20,000         |
+| NP                                          | The Nationals (Federal) NAT-FED                                                    | $20,000         |
+| Shooters                                    | Australian Fishing & Lifestyle Party                                               | $20,000         |
+| CEC                                         | Citizens Electoral Council Australia (NSW Division) - NSW                          | $19,975         |
+| ALP                                         | ALP-SA Australian Labor Party (SA Branch)                                          | $19,845         |
+| DEM                                         | Australian Democrats NSW Division - NSW                                            | $19,842         |
+| ALP                                         | ALP - SA                                                                           | $19,800         |
+| ALP                                         | ALP-FED ALP National Secretariat                                                   | $19,800         |
+| LIB                                         | Liberal Party of Australia, Tasmanian Division                                     | $19,250         |
+| LIB                                         | LIB-NSW - Ray King Fundraiser                                                      | $19,200         |
+| ALP                                         | Australian Labour Party (Federal Branch)                                           | $19,149         |
+| ALP                                         | ALP VIC Branch                                                                     | $19,006         |
+| GetUp                                       | Get Up Australia                                                                   | $18,955         |
+| GRN                                         | Tasmanian Greens                                                                   | $18,753         |
+| LIB                                         | LIB - TAS                                                                          | $18,700         |
+| LIB                                         | LPA Tasmania - LIB-TAS                                                             | $18,300         |
+| LIB                                         | Liberal Party of Australia - LIB                                                   | $18,255         |
+| GRN                                         | Australian Greens, Australian Capital Territory Branch (GRN-ACT)                   | $18,000         |
+| LIB                                         | LIBERAL PARTY OF AUSTRALIA/LIB-FED                                                 | $18,000         |
+| NP                                          | National Party NAT-FED                                                             | $18,000         |
+| LIB                                         | Liberal Party of Australia - SA Branch                                             | $17,797         |
+| ALP                                         | ALP (QLD)                                                                          | $17,750         |
+| GetUp                                       | Getup                                                                              | $17,703         |
+| ALP                                         | Progressive Business Association (ALP VIC)                                         | $17,640         |
+| GRN                                         | GRN-QLD                                                                            | $17,590         |
+| ALP                                         | ALP Australian Labor Party (ALP)                                                   | $17,500         |
+| LIB                                         | LIB-NSW Liberal Party of Australia (NSW Division)                                  | $17,500         |
+| LIB                                         | Liberal NSW - John Howard Fundraiser The Westin                                    | $17,500         |
+| LIB                                         | Liberal Party - North Sydney                                                       | $17,430         |
+| DEM                                         | Australian Democrats Queensland Division - QLD                                     | $17,404         |
+| LIB                                         | Liberal Party of Australia SA Division LIB-SA                                      | $17,350         |
+| PHON                                        | ONA                                                                                | $17,300         |
+| ALP                                         | Australian Labor Party (NSW)                                                       | $17,280         |
+| LIB                                         | LIB-TAS Liberal Party of Australia - Tasmanian Division                            | $17,200         |
+| LIB                                         | Liberal Party of Australia, Vic Division - LIB-VIC                                 | $17,093         |
+| ALP                                         | Australian Labor Party (ALP)/ALP                                                   | $17,066         |
+| ALP                                         | ALP CANNING ALP-WA                                                                 | $17,046         |
+| NP                                          | NAT - FED                                                                          | $17,038         |
+| ALP                                         | Australian Labor Party (NSW) Gifts Pty Ltd                                         | $17,000         |
+| GRN                                         | GRN-ACT                                                                            | $17,000         |
+| LIB                                         | Liberal Party of Australia (W.A. Div) Inc                                          | $17,000         |
+| ALP                                         | Australian Labor Party ALP-QLD                                                     | $16,920         |
+| ALP                                         | Progressive Business Association (ALP-VIC)                                         | $16,900         |
+| LIB                                         | Liberal Party of Aust LIB-FED HUME FEC                                             | $16,800         |
+| LIB                                         | Liberal Party of Australia -VIC LIB-VIC                                            | $16,550         |
+| ALP                                         | ALP (Membership of Federal Labor Business Forum)                                   | $16,500         |
+| ALP                                         | Australian Labor Party - Federal                                                   | $16,500         |
+| ALP                                         | Australian Labor Party QLD Branch/ALP-QLD                                          | $16,500         |
+| ALP                                         | Australian Labor Party/ALP FED                                                     | $16,500         |
+| LIB                                         | LNP Team Quirk Brisbane / LNP-QLD                                                  | $16,500         |
+| LIB                                         | LIB Fed                                                                            | $16,500         |
+| LIB                                         | The Millenium Forum - The Liberal Party of Australia (NSW Division)                | $16,500         |
+| NP                                          | National Party of Australia (NSW)                                                  | $16,500         |
+| NP                                          | Nationals Federal                                                                  | $16,500         |
+| LIB                                         | Liberal Party SA                                                                   | $16,436         |
+| NP                                          | Nats (WA)                                                                          | $16,340         |
+| LIB                                         | LIB-VIC Higgins 200 Club                                                           | $16,274         |
+| NP                                          | National Party of Australia NSW                                                    | $16,117         |
+| LIB                                         | The 500 Club                                                                       | $16,060         |
+| Green and Gold                              | Green and Gold Foundation                                                          | $16,000         |
+| Sus                                         | Stable Population Party of Australia                                               | $16,000         |
+| LDP                                         | LIBERAL DEMOCRATIC PARTY LDP                                                       | $15,856         |
+| ALP                                         | Australian Labor Party (Victorian Branch)/ALP-VIC                                  | $15,850         |
+| LIB                                         | Liberal Party of Australia, NSW Division (NSW) LIB-NSW                             | $15,620         |
+| LIB                                         | Liberal Party of Western Australia                                                 | $15,620         |
+| LIB                                         | LIB-NSW - NSW Division                                                             | $15,500         |
+| LIB                                         | LNP-QLD (Fairfax FDC)                                                              | $15,500         |
+| LIB                                         | The 500 Club (VIC) (Liberal Party - Victorian Division)                            | $15,500         |
+| DEM                                         | Australian Democrats - WA Division                                                 | $15,469         |
+| LIB                                         | Liberal Party of Australia NSW/LIB-NSW                                             | $15,465         |
+| ALP                                         | Australian Labor Party NSW                                                         | $15,450         |
+| Against Immigration                         | Australians Against Further Immigration - NATIONAL                                 | $15,420         |
+| ALP                                         | Australian Labor Party - (NSW)                                                     | $15,300         |
+| DEM                                         | Australian Democrats ACT Division - ACT                                            | $15,249         |
+| LIB                                         | Casey Business Briefing Club                                                       | $15,225         |
+| LIB                                         | Liberal Party of Australia (SA)                                                    | $15,020         |
+| ALP                                         | Chifley Research Centre                                                            | $15,000         |
+| ALP                                         | ALP - FED (2016 Federal Conference - Business program)                             | $15,000         |
+| ALP                                         | ALP NSW BRANCH                                                                     | $15,000         |
+| ALP                                         | ALP-NSW - NSW Branch Federal Campaign Account                                      | $15,000         |
+| ALP                                         | Australian Labor Party - NSW Branch - ALP-QLD                                      | $15,000         |
+| ALP                                         | Australian Labor Party (NT)                                                        | $15,000         |
+| ALP                                         | Australian Labor Party/ ALP-WA                                                     | $15,000         |
+| ALP                                         | WA Labor Party ALP-WA                                                              | $15,000         |
+| CLP                                         | CLP                                                                                | $15,000         |
+| CLP                                         | Country Liberal Party (CLP-NT)                                                     | $15,000         |
+| Hinch                                       | Derryn Hinch's Justice Party                                                       | $15,000         |
+| LIB                                         | Advance Aus Ltd                                                                    | $15,000         |
+| LIB                                         | LIB - ACT                                                                          | $15,000         |
+| LIB                                         | LIB-FED Liberal Party of Australia                                                 | $15,000         |
+| LIB                                         | LIB-VIC Liberal Party, Victorian Division                                          | $15,000         |
+| LIB                                         | LIB-WA - Cottesloe Liberal Campaign                                                | $15,000         |
+| LIB                                         | Liberal Party (W.A. Div) Inc                                                       | $15,000         |
+| LIB                                         | Liberal Party Campaign 2010                                                        | $15,000         |
+| LIB                                         | Liberal Party LIB-FED                                                              | $15,000         |
+| LIB                                         | Liberal Party of Australia (VIC Division) (paid to Kooyong 200 Club)               | $15,000         |
+| LIB                                         | Liberal Party of Australia (Victoria Division)                                     | $15,000         |
+| LIB                                         | LIBERAL PARTY OF AUSTRALIA / LIB-NSW                                               | $15,000         |
+| LIB                                         | LPA TAS Division                                                                   | $15,000         |
+| LIB                                         | The Liberal Party of Australia - Victoria Division                                 | $15,000         |
+| NP                                          | NEN                                                                                | $15,000         |
+| NP                                          | NATIONAL PARTY OF AUSTRALIA BARNABY JOYCE - NEW ENGLAND FEDERAL ELECTION CAMPAIGN  | $15,000         |
+| RiseUp                                      | Rise Up Australia Party (RUA)                                                      | $15,000         |
+| CLP                                         | CLP The Territory Party                                                            | $14,995         |
+| LIB                                         | Liberal Party of Australia - VIC - LIB-VIC                                         | $14,975         |
+| LIB                                         | Liberal Party Australia                                                            | $14,950         |
+| LIB                                         | Liberal Party of Australia (Lib-FED)                                               | $14,685         |
+| ACCI                                        | ACCI                                                                               | $14,619         |
+| ALP                                         | ALP - Australian Labor Party (National Secretariat)                                | $14,528         |
+| ALP                                         | Australian Labor Party - SA Branch ALP-SA                                          | $14,404         |
+| LIB                                         | Liberal Party of Australia Tasmanian Division / LIB-TAS                            | $14,300         |
+| ALP                                         | Australian Labor Party (VIC)                                                       | $14,200         |
+| NP                                          | The Nationals                                                                      | $14,170         |
+| LIB                                         | Advance Aus Ltd - Advance Australia                                                | $14,167         |
+| ALP                                         | Australian Labor Party - Victoria (ALP - VIC)                                      | $14,105         |
+| LIB                                         | Liberal Party of Australia / LIB-NSW                                               | $14,100         |
+| GetUp                                       | GETUP                                                                              | $14,000         |
+| GRN                                         | The Australian Greens (GRN-VIC) (Victorian Branch)                                 | $14,000         |
+| LIB                                         | LIB-NSW - Liberal Party of Australia NSW Division                                  | $14,000         |
+| LIB                                         | Liberal National Party - Art Union                                                 | $14,000         |
+| LIB                                         | Liberal Party of Aus-WA - LIB-WA                                                   | $14,000         |
+| PHON                                        | One Nation ONA-FED                                                                 | $14,000         |
+| LIB                                         | LIB-QLD                                                                            | $13,987         |
+| ALP                                         | Australian Labor Party - Victoria (ALP-VIC)                                        | $13,883         |
+| ALP                                         | ALP-VIC                                                                            | $13,835         |
+| LIB                                         | Liberal Party (Prahran 200 Club)                                                   | $13,800         |
+| ALP                                         | Australian Labor Party (NSW Branch                                                 | $13,750         |
+| ALP                                         | Australian Labor Party (Victorian Branch) - ALP-VIC                                | $13,750         |
+| ALP                                         | NSW Labor Business Dialogue 2009-1010                                              | $13,750         |
+| ALP                                         | Progressive Business Association (ALP Victoria)                                    | $13,738         |
+| ALP                                         | Progressive Business Association ALP-SA                                            | $13,650         |
+| NP                                          | The Nationals Federal Secretariat - NAT                                            | $13,640         |
+| ALP                                         | ALP NSW Federal Campaign Account                                                   | $13,575         |
+| ALP                                         | Australia Labor Party - Victoria (ALP-VIC)                                         | $13,545         |
+| LIB                                         | The Liberal Party of Australia (NSW Division)                                      | $13,516         |
+| GRN                                         | GRN-TAS                                                                            | $13,500         |
+| NP                                          | The Nationals for Regional NSW                                                     | $13,450         |
+| ALP                                         | Australian Labor Party NSW Branch Federal Campain Account - ALP-NSW                | $13,400         |
+| LIB                                         | Liberal Party of Aus - LIB-WA                                                      | $13,400         |
+| NP                                          | Nats-Federal                                                                       | $13,368         |
+| NP                                          | Nationals                                                                          | $13,272         |
+| ChristDem                                   | CDP                                                                                | $13,260         |
+| ALP                                         | Australian Labor Party (South Australian Branch)/ALP-SA                            | $13,230         |
+| PHON                                        | Pauline Hanson's One Nation - Queensland                                           | $13,200         |
+| NP                                          | Nationals (Fed)                                                                    | $13,190         |
+| NP                                          | National Party of Australia - N.S.W NAT-NSW                                        | $13,030         |
+| ALP                                         | Australian Labor Party - ALP-VIC                                                   | $13,000         |
+| LIB                                         | Liberal Party of Australia – ACT Division                                          | $12,950         |
+| ALP                                         | Progressive Business ALP-VIC                                                       | $12,901         |
+| ALP                                         | Secondment - ALP-FED                                                               | $12,836         |
+| Online                                      | Senator On-Line                                                                    | $12,795         |
+| LIB                                         | Liberal Party of Australia, NSW / LIB-NSW                                          | $12,730         |
+| NP                                          | National Party of Australia - NAT-FED                                              | $12,650         |
+| ALP                                         | Australian Labor Party (SA Branch) / ALP-SA                                        | $12,565         |
+| Christ                                      | Australian Christians ACH-FED                                                      | $12,500         |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) WA Branch CDP-WA                      | $12,500         |
+| FFP                                         | Family First Party - SA                                                            | $12,500         |
+| LIB                                         | LIBERAL NATIONAL SPRING HILL                                                       | $12,500         |
+| LIB                                         | Liberal Party - ALP-SA - SA Liberal Party Appeal - Graham Ingerson                 | $12,500         |
+| LIB                                         | Liberal Party of Aus                                                               | $12,500         |
+| Secular                                     | The Secular Party of Australia                                                     | $12,500         |
+| LIB                                         | Liberal Party of Australia (Victorian Division) / LIB-VC                           | $12,445         |
+| LIB                                         | Liberal Party of Australia LIB-ACT                                                 | $12,445         |
+| NP                                          | National Party of Australia (S.A.) Inc. - SA                                       | $12,350         |
+| LIB                                         | Liberal Party of Australia (Victorian Division)/LIB-VIC                            | $12,310         |
+| LIB                                         | Liberal National Party - QLD                                                       | $12,272         |
+| LIB                                         | Liberal Party of Australia VIC - Enterprise 500 Victoria                           | $12,240         |
+| LIB                                         | Liberal Party of Western Australia Pty Ltd                                         | $12,160         |
+| ALP                                         | Australian Labor Party (Victoria Branch)                                           | $12,000         |
+| ALP                                         | Michael Danby's Re-Election Campaign - ALP - Vic                                   | $12,000         |
+| CLP                                         | CLP Gifts and Legacies Pty Ltd                                                     | $12,000         |
+| FFP                                         | Family First Party - SA (FFP-SA)                                                   | $12,000         |
+| LIB                                         | LIB (Sturt FEC)                                                                    | $12,000         |
+| LIB                                         | LIB (VIC) (Membership of Enterprise 500)                                           | $12,000         |
+| LIB                                         | Lib-Tas                                                                            | $12,000         |
+| LIB                                         | Liberal National Party QLD LNP-QLD                                                 | $12,000         |
+| LIB                                         | LIBERAL PARTY OF AUST-NSW DIVISION (LIB-NSW)                                       | $12,000         |
+| LIB                                         | Liberal Party of Australia - Tasmanian Division (LIB-TAS)                          | $12,000         |
+| LIB                                         | Liberal Party of Australia - Tasmanian Division/LIB-TAS                            | $12,000         |
+| LIB                                         | Liberal Party of Australia (Lib-VIC)                                               | $12,000         |
+| LIB                                         | Millenium Forum / LIB-NSW                                                          | $12,000         |
+| NP                                          | National Party Australia                                                           | $11,870         |
+| LIB                                         | Liberal Party of Australia - Federal                                               | $11,850         |
+| LIB                                         | Liberal Party of Australia - VIC Branch                                            | $11,725         |
+| LIB                                         | Liberal Party of Australia (LIB/VIC)                                               | $11,700         |
+| LIB                                         | Liberal Party of Australia (VIC Division) Entreprise 500                           | $11,500         |
+| NP                                          | NATS-FED                                                                           | $11,450         |
+| LIB                                         | LIB (57th Federal Council - Bus. Observer)                                         | $11,250         |
+| ALP                                         | Australian Labor Party - ALP-QLD                                                   | $11,176         |
+| ALP                                         | ALP - QLD (2015 State Conference & Business program)                               | $11,000         |
+| ALP                                         | ALP Victoria                                                                       | $11,000         |
+| ALP                                         | Australian Labor Party (NSW)                                                       | $11,000         |
+| ALP                                         | Jewish Labor Forum                                                                 | $11,000         |
+| ALP                                         | Labour Movement Education Association Inc.                                         | $11,000         |
+| LIB                                         | LIB - Conference: Business Observers Programme                                     | $11,000         |
+| LIB                                         | LIB-FED: Business Observer Program, 56th Fed. Council                              | $11,000         |
+| LIB                                         | LIB-WA - WA Conference                                                             | $11,000         |
+| LIB                                         | Liberal Party (Fed)                                                                | $11,000         |
+| LIB                                         | LNP - QLD (2016 State Conference & Q Forum subscription)                           | $11,000         |
+| LIB                                         | LPA NSW Division Incorporated - North Sydney Forum                                 | $11,000         |
+| LIB                                         | Millenium Forum - Liberal Party of NSW                                             | $11,000         |
+| LIB                                         | Millenium Forum / Lib-NSW                                                          | $11,000         |
+| LIB                                         | Millenium Forum Business Membership                                                | $11,000         |
+| LIB                                         | North Sydney Forum - LIB-FED                                                       | $11,000         |
+| LIB                                         | NSW Liberal Millenium Forum 2009-2010                                              | $11,000         |
+| LIB                                         | The Liberal Party of Australia LIB-FED                                             | $11,000         |
+| NP                                          | The National Federal Secretariat                                                   | $11,000         |
+| PHON                                        | Pauline Hansons One Nation QLD                                                     | $10,908         |
+| LIB                                         | Bayside Forum                                                                      | $10,870         |
+| LIB                                         | Liberal Party of Australia - LIB-FED                                               | $10,800         |
+| LIB                                         | Lib-NSW Federal Campaign                                                           | $10,700         |
+| LIB                                         | Liberal Party of Australia - NSW (LIB-NSW)                                         | $10,641         |
+| Tasmania                                    | Tasmania First Party                                                               | $10,500         |
+| LIB                                         | LNP-QLD - LNP Conference                                                           | $10,450         |
+| ALP                                         | ALP NSW Division - ALP-NSW                                                         | $10,250         |
+| Brisbane                                    | The Brisbane Future Committee                                                      | $10,250         |
+| LIB                                         | Liberal Party of Australia - LIB-VIC                                               | $10,250         |
+| Save bush                                   | Save the ADI Site Party - NSW                                                      | $10,230         |
+| LIB                                         | Liberal Party of Australia LIB-WA                                                  | $10,150         |
+| ALP                                         | SA Progressive Business / ALP-SA                                                   | $10,099         |
+| LIB                                         | Liberal Party VIC Division                                                         | $10,035         |
+| AHA                                         | Australian Hotels Association                                                      | $10,000         |
+| ALP                                         | Mike Kelly MP Eden-Monaro Re-Election campaign                                     | $10,000         |
+| ALP                                         | ALP - Hume (Robin Saville)(ALP-NSW)                                                | $10,000         |
+| ALP                                         | ALP - Macarthur (Nick Bleasdale)(ALP-NSW)                                          | $10,000         |
+| ALP                                         | ALP - QLD (2015 State Conference - Business program)                               | $10,000         |
+| ALP                                         | ALP Maribyrnong FEA - Shorten Account                                              | $10,000         |
+| ALP                                         | ALP NSW EDEN MONARO CAMPAIGN                                                       | $10,000         |
+| ALP                                         | ALP-NT Karama Fundraising Acct                                                     | $10,000         |
+| ALP                                         | ALP-QLD (Dawson)                                                                   | $10,000         |
+| ALP                                         | ALP-Tasmania Lyons (Dick Adams)                                                    | $10,000         |
+| ALP                                         | Australian Labor Party - Isaacs                                                    | $10,000         |
+| ALP                                         | Australian Labor Party ALP FED                                                     | $10,000         |
+| ALP                                         | Australian Labor Party N.S.W. Branch (Federal Account)                             | $10,000         |
+| ALP                                         | Australian Labor Party Queensland ALP-QLD                                          | $10,000         |
+| ALP                                         | Camden State Campaign Labor NSW                                                    | $10,000         |
+| ALP                                         | Federal Labor Business Forum                                                       | $10,000         |
+| ALP                                         | K Rudd - Griffith FEC Account - ALP QLD                                            | $10,000         |
+| ALP                                         | Lindsay FEC - ALP-FED                                                              | $10,000         |
+| ALP                                         | Matt Thistlewaite Campaign a/c - ALP-NSW                                           | $10,000         |
+| Christ                                      | Australian Conservatives (SA)                                                      | $10,000         |
+| CLP                                         | CLP-NT - Lia Finocchiaro                                                           | $10,000         |
+| FFP                                         | Family First Party - VIC - VIC                                                     | $10,000         |
+| GRN                                         | Australian Greens Queensland Branch                                                | $10,000         |
+| LIB                                         | LNP BRISBANE                                                                       | $10,000         |
+| LIB                                         | advance australia                                                                  | $10,000         |
+| LIB                                         | Christopher Pyne (Lib Fed)                                                         | $10,000         |
+| LIB                                         | Dunkley FEC (Libs Fed)                                                             | $10,000         |
+| LIB                                         | Enterprise 500 Vic Connecting Leaders/LIB-VIC                                      | $10,000         |
+| LIB                                         | Enterprise 500 Victoria                                                            | $10,000         |
+| LIB                                         | Fairfax FDC (Libs Fed)                                                             | $10,000         |
+| LIB                                         | Five Hundred Club                                                                  | $10,000         |
+| LIB                                         | Kew Electorate Conference - Liberal Party of Australia - Vic Division              | $10,000         |
+| LIB                                         | LIB Party of Australia (WA Division)                                               | $10,000         |
+| LIB                                         | LIB-FEC                                                                            | $10,000         |
+| LIB                                         | Lib-FED Menzies Research Centre                                                    | $10,000         |
+| LIB                                         | LIB-NSW - NSW Federal Campaign Account                                             | $10,000         |
+| LIB                                         | LIB-SA, Sturt FEC                                                                  | $10,000         |
+| LIB                                         | LIB-SA/Cory Bernardi Campaign Fund                                                 | $10,000         |
+| LIB                                         | LIB-VIC - Liberal Party of Australia (Victorian Division)                          | $10,000         |
+| LIB                                         | LIBERAL NEW SOUTH WALES                                                            | $10,000         |
+| LIB                                         | Liberal Part NSW Division                                                          | $10,000         |
+| LIB                                         | Liberal Party - Federal Heffernan                                                  | $10,000         |
+| LIB                                         | Liberal Party - Simcha Federal                                                     | $10,000         |
+| LIB                                         | Liberal Party (LIB-VIC)                                                            | $10,000         |
+| LIB                                         | Liberal Party of Aust - VIC                                                        | $10,000         |
+| LIB                                         | Liberal Party of Aust LIB-FED Warringah FEC                                        | $10,000         |
+| LIB                                         | LIBERAL PARTY OF AUST- NO.2 A/C (LIB-FED)                                          | $10,000         |
+| LIB                                         | Liberal Party of Australia - NSW Division Warringah FEC (LIB-NSW)                  | $10,000         |
+| LIB                                         | LIBERAL PARTY OF AUSTRALIA (Federal)                                               | $10,000         |
+| LIB                                         | LIBERAL PARTY OF AUSTRALIA (LIB-FED)                                               | $10,000         |
+| LIB                                         | Liberal Party of Australia (S.A. Division) LIB-SA                                  | $10,000         |
+| LIB                                         | Liberal Party of Australia (Vic Div) Kooyong 200 Club                              | $10,000         |
+| LIB                                         | LIBERAL PARTY OF AUSTRALIA (VIC) DIVISION KOOYONG ELECTORATE CONFERENCE            | $10,000         |
+| LIB                                         | Liberal Party of Australia LIB FED                                                 | $10,000         |
+| LIB                                         | LIberal Party of Australia Lib-Fed                                                 | $10,000         |
+| LIB                                         | Liberal Party of Australia VIC Division (Menzies 200 Club)                         | $10,000         |
+| LIB                                         | Liberal Party of Australia, Hartley FEC                                            | $10,000         |
+| LIB                                         | Liberal Party of Australia, Sturt FEC                                              | $10,000         |
+| LIB                                         | Liberal Party of NSW LIB-NSW                                                       | $10,000         |
+| LIB                                         | Liberal Party WA                                                                   | $10,000         |
+| LIB                                         | LIBERAL VICTORIA/LIB-VIC                                                           | $10,000         |
+| LIB                                         | LNP - Dickson                                                                      | $10,000         |
+| LIB                                         | LNP - Queensland                                                                   | $10,000         |
+| LIB                                         | LNP Ashgrove Sec/LNP-QLD                                                           | $10,000         |
+| LIB                                         | LNP Mermaid Beach                                                                  | $10,000         |
+| LIB                                         | LNP-QLD - Planning Forum, QLD                                                      | $10,000         |
+| LIB                                         | LPA VIC Division                                                                   | $10,000         |
+| LIB                                         | Millenium Forum - Liberal Party of Australia (NSW Division)                        | $10,000         |
+| LIB                                         | Millenium Forum Sponsor Business - Liberal Party of Australia - NSW                | $10,000         |
+| LIB                                         | Perth Liberal Party (LIB-WA)                                                       | $10,000         |
+| LIB                                         | Senator Mathias Corman Liberal Party Camp A/C - LIB-WA                             | $10,000         |
+| LIB                                         | STURT FEC                                                                          | $10,000         |
+| LIB                                         | Sturt FEC - LIB-SA                                                                 | $10,000         |
+| LIB                                         | The Liberal Party of Australia, Sturt FEC                                          | $10,000         |
+| NP                                          | NAT - Federal National Forum                                                       | $10,000         |
+| NP                                          | NAT-NSW - National Party of Australia NSW                                          | $10,000         |
+| NP                                          | NATIONALS NAT-FED                                                                  | $10,000         |
+| NP                                          | The Nationals (Gippsland Nationals Federal Campaign Committee)                     | $10,000         |
+| SEP                                         | Socialist Equality Party                                                           | $10,000         |
+| UAP                                         | LNP unit FDC Dickson                                                               | $10,000         |
+| XEN                                         | XEN - Nick Xenephon Team                                                           | $10,000         |
+| Hope                                        | Hope Party Australia - ethics equality ecology - NATIONAL                          | $9,870          |
+| ALP                                         | ALP-WA (ALP Brand Election Campaign - Gary Gray)                                   | $9,500          |
+| LIB                                         | Liberal Party NSW Division - Bradfield                                             | $9,410          |
+| LIB                                         | LIB - VIC (Enterprise Victoria)                                                    | $9,405          |
+| LIB                                         | Liberal Party of Australia (NSW) Ryde Forum                                        | $9,400          |
+| ALP                                         | Australian Labor Party - VIC / ALP-VIC                                             | $9,250          |
+| NP                                          | National Party of Australia (NSW Branch)                                           | $9,250          |
+| LIB                                         | LIB-SA Liberal Party of Australia (SA Division)                                    | $9,200          |
+| Great                                       | The Great Australians - QLD                                                        | $9,143          |
+| LIB                                         | Liberal Party of Australia – Tasmanian Division                                    | $9,000          |
+| LIB                                         | Liberal Party of Australia /LIB-NSW                                                | $9,000          |
+| LIB                                         | LIB -SA                                                                            | $8,800          |
+| NP                                          | NAT -FED                                                                           | $8,800          |
+| NP                                          | National Party of Australia (NAT)                                                  | $8,800          |
+| ALP                                         | Progressive Business (ALP-VIC)                                                     | $8,765          |
+| ALP                                         | Australian Labor Party (Vic Branch)                                                | $8,755          |
+| NP                                          | NAT-NSW National Party of Australia - N.S.W.                                       | $8,700          |
+| LIB                                         | LPA - LIB-FED                                                                      | $8,550          |
+| ALP                                         | ALP LINDSAY ALP-NSW                                                                | $8,532          |
+| LIB                                         | Liberal National Party of Queensland - LNP-QLD                                     | $8,495          |
+| ALP                                         | Federal Labor Business Forum / ALP-FED                                             | $8,470          |
+| NP                                          | National Party of Australia (NSW Division)                                         | $8,400          |
+| ALP                                         | Australian Labor Party - WA Branch                                                 | $8,376          |
+| LIB                                         | LNP-QLD - LNP National Convention - Brisbane                                       | $8,300          |
+| LIB                                         | LNP-QLD - State LNP Annual Conference - Toowoomba                                  | $8,300          |
+| NP                                          | The National Party - NAT-WA                                                        | $8,280          |
+| ALP                                         | Progressive Business Forum - registration fee                                      | $8,250          |
+| LIB                                         | Liberal Party - 54th Federal Council / LIB-FED                                     | $8,250          |
+| NP                                          | National Party of Australia (NAT-FED)                                              | $8,250          |
+| ALP                                         | Australian Labor Party - NSW / ALP-NSW                                             | $8,220          |
+| LIB                                         | Liberal Party of Australia (NSW Division) Ryde Forum                               | $8,175          |
+| ALP                                         | Australian Labor Party (South Australian Branch) / ALP-SA                          | $8,155          |
+| ALP                                         | Australian Labor Party (National Secretariat) ALP-FED                              | $8,100          |
+| ALP                                         | ALP-ACT                                                                            | $8,093          |
+| SA                                          | Socialist Alliance - NATIONAL                                                      | $8,020          |
+| ALP                                         | Lyndhurst SECC                                                                     | $8,000          |
+| ALP                                         | ALP - Cunningham (Sharon Bird)(ALP-NSW)                                            | $8,000          |
+| ALP                                         | ALP - Throsby (Stephen Jones)(ALP-NSW)                                             | $8,000          |
+| ALP                                         | Labor Friends of Israel - Australian Labor Party - Vic                             | $8,000          |
+| LIB                                         | LNP-QLD - LNP Forward Brisbane Leadership                                          | $8,000          |
+| LIB                                         | Cook FEC                                                                           | $8,000          |
+| LIB                                         | Ian Macfarlane, Member for Groom/Liberal Party of Australia                        | $8,000          |
+| LIB                                         | Liberal Vic, Kooyong Electorate Conference                                         | $8,000          |
+| Progressive                                 | Australian Progressive Alliance - NATIONAL                                         | $8,000          |
+| LIB                                         | LIB - Fed                                                                          | $7,970          |
+| ALP                                         | Mike Kelly, Member for Monaro/ALP                                                  | $7,817          |
+| LIB                                         | Liberal Party QLD                                                                  | $7,700          |
+| LIB                                         | LNP - QLD (Business event with Minister)                                           | $7,700          |
+| ALP                                         | Australian Labor Party - ACT Branch                                                | $7,622          |
+| LIB                                         | Senator David Johnston, Liberal Party of Australia (WA Div)                        | $7,600          |
+| ALP                                         | ALP-QLD                                                                            | $7,500          |
+| ALP                                         | Federal Labor Business Exchange (ALP-FED)                                          | $7,500          |
+| ALP                                         | Robertson Labor Campaign - ALP-NSW                                                 | $7,500          |
+| LIB                                         | Aston Liberal Federal Electorate Conference LIB-VIC                                | $7,500          |
+| LIB                                         | The Liberal Party of Australia - Kooyong Electorate                                | $7,500          |
+| NP                                          | The Nationals NAT-FED                                                              | $7,500          |
+| XEN                                         | Nick Xenophon Team                                                                 | $7,500          |
+| ALP                                         | Perth Trades Hall Inc                                                              | $7,364          |
+| LIB                                         | Liberal Party of Australia - Tasmania Division - LIB-TAS                           | $7,300          |
+| ALP                                         | QLD ALP                                                                            | $7,150          |
+| ALP                                         | WA-ALP                                                                             | $7,050          |
+| LIB                                         | Liberal Party of Australia - SA - LIB-SA                                           | $7,036          |
+| ALP                                         | ALP                                                                                | $7,000          |
+| ALP                                         | ALP-QLD / Australian Labor Party - QLD                                             | $7,000          |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group)                                       | $7,000          |
+| LDP                                         | Liberal Democratic Party (WA Branch)                                               | $7,000          |
+| LIB                                         | LIB-VIC Higgins Electorate Conference                                              | $7,000          |
+| LIB                                         | Liberal Party LIB-WA                                                               | $7,000          |
+| LIB                                         | LNP Bowman Federal Divisional/LNP-QLD                                              | $7,000          |
+| LIB                                         | LPA VIC Division - LIB-VIC                                                         | $7,000          |
+| LIB                                         | Mackellar Business Forum - LIB                                                     | $7,000          |
+| LIB                                         | Mackellar Business Forum (Liberal Party)                                           | $7,000          |
+| NP                                          | John McEwen House Pty Ltd (NAT-FED)                                                | $7,000          |
+| LIB                                         | Liberal Party of Australia (VIC Division) Menzies Reserach Cen                     | $6,982          |
+| LIB                                         | LIB-QLD: Corporate Observer M/Ship - Type A/B                                      | $6,875          |
+| ALP                                         | Australian Labor Party - ALP-SA                                                    | $6,740          |
+| NP                                          | NSW Nationals                                                                      | $6,738          |
+| LIB                                         | Liberal Party of Australia - SA                                                    | $6,660          |
+| LIB                                         | Liberal - NSW                                                                      | $6,636          |
+| LIB                                         | Lib - Fed: Business Briefing Program                                               | $6,600          |
+| LIB                                         | LIB-ACT - Federal Secretariat                                                      | $6,600          |
+| NP                                          | National Party VIC                                                                 | $6,600          |
+| LIB                                         | LIB-SA (Hindmarsh FEC)                                                             | $6,552          |
+| LIB                                         | LIB-NSW - Hughes FEC Federal Campaign                                              | $6,500          |
+| NP                                          | National Party of Australia NSW Federal Campaign Account                           | $6,500          |
+| First                                       | Australia First Party                                                              | $6,400          |
+| RTorbay                                     | Richard Torbay                                                                     | $6,340          |
+| ALP                                         | Australian Labor Party - QLD/ALP-QLD                                               | $6,300          |
+| LIB                                         | Liberal Party of Australia - QLD Branch                                            | $6,300          |
+| LIB                                         | LNP (QLD)                                                                          | $6,250          |
+| NP                                          | National Party of Australia - NSW (NAT-NSW)                                        | $6,250          |
+| ALP                                         | ALP (ACT)                                                                          | $6,125          |
+| ALP                                         | ALP- NSW                                                                           | $6,100          |
+| ALP                                         | Country Labor Party - CLR-NSW                                                      | $6,100          |
+| LIB                                         | LPA TAS Division - LIB-TAS                                                         | $6,040          |
+| ALP                                         | Hughes Federal Campaign a/c - ALP-NSW                                              | $6,000          |
+| ALP                                         | SA Progressive Business Inc / ALP-SA                                               | $6,000          |
+| Brisbane                                    | The Brisbane Futures Committee                                                     | $6,000          |
+| LIB                                         | Advance Australia Party                                                            | $6,000          |
+| LIB                                         | LIB - VIC (2016 State Conference - Business program)                               | $6,000          |
+| LIB                                         | LIB NAT-QLD                                                                        | $6,000          |
+| LIB                                         | Liberal National Party Qld                                                         | $6,000          |
+| LIB                                         | Liberal Party (National)                                                           | $6,000          |
+| PCleary                                     | Phil Cleary - Independent Australia - NATIONAL                                     | $6,000          |
+| NP                                          | NAT-FED - National Party of Australia Federal Council                              | $5,940          |
+| NP                                          | National Party (Fed)                                                               | $5,940          |
+| Natural Law                                 | Natural Law Party (National)                                                       | $5,816          |
+| LIB                                         | LNP Bowman FDC                                                                     | $5,800          |
+| LIB                                         | Bradfield Forum - LIB-FED                                                          | $5,700          |
+| LIB                                         | Kooyong 200 Club                                                                   | $5,700          |
+| NP                                          | NAT-VIC                                                                            | $5,700          |
+| ALP                                         | Australian Labor Party - ALP-NSW                                                   | $5,550          |
+| ALP                                         | ALP (Dinner PM Kevin Rudd)                                                         | $5,500          |
+| ALP                                         | ALP-FED: Board Room Dinner with PM Julia Gillard                                   | $5,500          |
+| ALP                                         | ALP-VIC (Progressive Business)                                                     | $5,500          |
+| KAP                                         | KAP                                                                                | $5,500          |
+| LIB                                         | Business Observers' Programme / LIB-WA                                             | $5,500          |
+| LIB                                         | Casey Fed Election Conference (LIB)                                                | $5,500          |
+| LIB                                         | Liberal Party - David Ridgway / LIB/SA                                             | $5,500          |
+| LIB                                         | LIBERAL PARTY FEDERAL FORUM (LIB-FED)                                              | $5,500          |
+| LIB                                         | Liberal Party of Australia - Millennium Forum                                      | $5,500          |
+| LIB                                         | Liberal Party of Australia - VIC / LIB-VIC                                         | $5,500          |
+| LIB                                         | Liberal Party of Australia (S.A Division)/LIB-SA                                   | $5,500          |
+| LIB                                         | Liberal Party of Australia, NSW Division (Federal Acct)                            | $5,500          |
+| LIB                                         | LNP - FDC Dickson                                                                  | $5,500          |
+| LIB                                         | LNP-QLD - LIberal National Party QLD                                               | $5,500          |
+| LIB                                         | LPA VIC Divison - LIB-VIC                                                          | $5,500          |
+| LIB                                         | Millenium Forum (LIB-NSW)                                                          | $5,500          |
+| LIB                                         | North Sydney Forum - Liberal Party of Australia, NSW Division (LIB-NSW)            | $5,500          |
+| NP                                          | National Party of Australia - N.S.W                                                | $5,500          |
+| NP                                          | National Party of Australia - VIC / NAT-VIC                                        | $5,500          |
+| NP                                          | National Party of Australia – N.S.W.                                               | $5,500          |
+| NP                                          | NSW Nationals Annual General Conference                                            | $5,500          |
+| Tasmania                                    | Tasmania First Party - NATIONAL                                                    | $5,485          |
+| NP                                          | National Party of Australia - NSW Branch                                           | $5,454          |
+| ALP                                         | ALP BURT ALP-WA                                                                    | $5,440          |
+| Hope                                        | Hope Party Australia - NATIONAL                                                    | $5,394          |
+| LIB                                         | Liberal Party of Australia - LIB-SA                                                | $5,340          |
+| ALP                                         | ALP - National Secretariat                                                         | $5,200          |
+| ALP                                         | ALP (WA)                                                                           | $5,200          |
+| NP                                          | NAT-FED National Party of Australia                                                | $5,200          |
+| LIB                                         | The Page Research Centre Ltd                                                       | $5,190          |
+| Sydney Alliance                             | Sydney Alliance Limited                                                            | $5,000          |
+| ALP                                         | Hon Jason Clare MP                                                                 | $5,000          |
+| ALP                                         | The Chifley Research Centre Ltd                                                    | $5,000          |
+| ALP                                         | ALP - Calare (Kevin Duffy)(ALP-NSW)                                                | $5,000          |
+| ALP                                         | ALP - Forde FDE                                                                    | $5,000          |
+| ALP                                         | ALP - Moncreif FDE                                                                 | $5,000          |
+| ALP                                         | ALP FLYNN ALP-QLD                                                                  | $5,000          |
+| ALP                                         | ALP GREY ALP-SA                                                                    | $5,000          |
+| ALP                                         | ALP National Secretaria                                                            | $5,000          |
+| ALP                                         | ALP NSW (Nigel Gould)                                                              | $5,000          |
+| ALP                                         | ALP NSW Branch - Chifley FEC                                                       | $5,000          |
+| ALP                                         | ALP Tasmania Braddon (Sid Sidebottom)                                              | $5,000          |
+| ALP                                         | ALP Tasmania Franklin (Julie Collins)                                              | $5,000          |
+| ALP                                         | ALP-QLD - Australian Labor Party (State of Queensland)                             | $5,000          |
+| ALP                                         | ALP-TAS / Australian Labor Party - Tas                                             | $5,000          |
+| ALP                                         | ALP-WA - Australian Labor Party (Western Australian Branch)                        | $5,000          |
+| ALP                                         | AUSTRALIAN LABOR PART/ALP-ACT                                                      | $5,000          |
+| ALP                                         | Australian Labor Party - Eden Monaro Federal Campaign                              | $5,000          |
+| ALP                                         | Australian Labor Party - QLD / ALP-QLD                                             | $5,000          |
+| ALP                                         | Australian Labor Party - TAS / ALP-TAS                                             | $5,000          |
+| ALP                                         | Australian Labor Party (NSW Branch) Fed                                            | $5,000          |
+| ALP                                         | Australian Labor Party (Queensland Branch)                                         | $5,000          |
+| ALP                                         | Australian Labour Party - National Secretariat                                     | $5,000          |
+| ALP                                         | Australian Labour Party (SA Branch) ALP-SA                                         | $5,000          |
+| ALP                                         | Bliar Campaign QLD Labor Party                                                     | $5,000          |
+| ALP                                         | Country Labor Party/CLR-NSW                                                        | $5,000          |
+| ALP                                         | Doboy MEC ALP (ALP QLD)                                                            | $5,000          |
+| ALP                                         | Drummoyne State Campaign A/C ALP-NSW                                               | $5,000          |
+| ALP                                         | Forward Ipswich Inc (ALP QLD)                                                      | $5,000          |
+| ALP                                         | Forward Ipswich Inc. (ALP QLD)                                                     | $5,000          |
+| ALP                                         | Hunter Federal Campaign Account - ALP-NSW                                          | $5,000          |
+| ALP                                         | Lalor FEA Campaign Account Australian Labor Party National Secretariat             | $5,000          |
+| ALP                                         | Michael Danby MHR - ALP Melbourne Ports                                            | $5,000          |
+| ALP                                         | Senator Glen Sterle ALP Cmapaign                                                   | $5,000          |
+| ALP                                         | The State Secretary - ALP QLD - ALP-QLD                                            | $5,000          |
+| ALP                                         | Yvette D'ath MP ALP Petire FEC                                                     | $5,000          |
+| Christ                                      | Australian Conservatives ACP                                                       | $5,000          |
+| Christ                                      | Australian Conservatives ACP FED                                                   | $5,000          |
+| FFP                                         | Family First Party - QLD                                                           | $5,000          |
+| GetUp                                       | GetUp                                                                              | $5,000          |
+| GLazarus                                    | Glen Lazarus Team - GLT                                                            | $5,000          |
+| GRN                                         | Australian Greens - TAS / GRN-TAS                                                  | $5,000          |
+| LIB                                         | LNP - LNP Brisbane FDC 00260                                                       | $5,000          |
+| LIB                                         | Liberal Lord Mayor of Brisbane                                                     | $5,000          |
+| LIB                                         | Mackellar Business Forum                                                           | $5,000          |
+| LIB                                         | 2010 Business Forum - Liberal Party of NSW                                         | $5,000          |
+| LIB                                         | Aston Electorate Committee - LIB-VIC                                               | $5,000          |
+| LIB                                         | Eden Monaro FEC (Lib Fed)                                                          | $5,000          |
+| LIB                                         | Eden-Monaro FEC - LIB-NSW                                                          | $5,000          |
+| LIB                                         | Epping SEC Liberal NSW                                                             | $5,000          |
+| LIB                                         | G Ward - Liberal Party NSW                                                         | $5,000          |
+| LIB                                         | Heads G WardLiberal South Coast                                                    | $5,000          |
+| LIB                                         | JULIAN LEESER'S ELECTION CAMPAIGN/LIB-NSW                                          | $5,000          |
+| LIB                                         | LIB - WA                                                                           | $5,000          |
+| LIB                                         | LIB-SA - Andrew Southcott                                                          | $5,000          |
+| LIB                                         | LIB-SA - Christopher Pyne                                                          | $5,000          |
+| LIB                                         | LIB-SA - Matthew Williams                                                          | $5,000          |
+| LIB                                         | LIB-SA, Hartley SEC                                                                | $5,000          |
+| LIB                                         | LIB-SA, Hindmarsh FEC                                                              | $5,000          |
+| LIB                                         | LIB-SA, LIB-SA, Hartley SEC                                                        | $5,000          |
+| LIB                                         | LIB-VIC Higgins Federal Electorate Conference                                      | $5,000          |
+| LIB                                         | LIB-WA - Dinner 2013                                                               | $5,000          |
+| LIB                                         | LIB-WA - Liberal Party (W.A. Division) Inc.                                        | $5,000          |
+| LIB                                         | Liberal National Party (Jane Prentice)                                             | $5,000          |
+| LIB                                         | Liberal National Party (QLD)                                                       | $5,000          |
+| LIB                                         | Liberal Party NSW Nth Syd FEC Nthwd NS                                             | $5,000          |
+| LIB                                         | Liberal Party of Aust - Lib NSW                                                    | $5,000          |
+| LIB                                         | LIBERAL PARTY OF AUSTRALI/LIB-FED                                                  | $5,000          |
+| LIB                                         | Liberal Party of Australia - Mackellar Business Forum                              | $5,000          |
+| LIB                                         | Liberal Party of Australia - NSW Division - LIB NSW                                | $5,000          |
+| LIB                                         | Liberal Party of Australia - TAS / LIB-TAS                                         | $5,000          |
+| LIB                                         | Liberal Party of Australia - VIC/LIB-VIC                                           | $5,000          |
+| LIB                                         | Liberal Party of Australia (NSW Division - Manly SEC)                              | $5,000          |
+| LIB                                         | Liberal Party of Australia / LIB                                                   | $5,000          |
+| LIB                                         | Liberal Party of Australia Tasmania LIB-TAS                                        | $5,000          |
+| LIB                                         | Liberal Party of Australia- Victorian Division                                     | $5,000          |
+| LIB                                         | Liberal Party of Australia, NSW Division / LIB/NSW                                 | $5,000          |
+| LIB                                         | Liberal Party SA Division (Mayo FEC)                                               | $5,000          |
+| LIB                                         | LIBERAL PARTY- FOR DR STEPHEN RUSS                                                 | $5,000          |
+| LIB                                         | LNP DICKSON                                                                        | $5,000          |
+| LIB                                         | LNP-QLD - Federal Budget reply                                                     | $5,000          |
+| LIB                                         | Menzies Research Centre Limited                                                    | $5,000          |
+| LIB                                         | Parramatta Business Network                                                        | $5,000          |
+| LIB                                         | WARRINGAH LIBERAL CAMPAIGN/LIB-NSW                                                 | $5,000          |
+| MNevill                                     | Mark Nevill MLC                                                                    | $5,000          |
+| NP                                          | National Party of Australia, WA Division/ NAT-WA                                   | $5,000          |
+| Shooters                                    | Australian Shooters Party - NATIONAL                                               | $5,000          |
+| VECCI                                       | VECCI Finance & Administration                                                     | $5,000          |
+| ALP                                         | ALP Progressive Business Association                                               | $4,950          |
+| NP                                          | National Federal Secretariat                                                       | $4,950          |
+| LIB                                         | Higgins 200 Club LIB VIC                                                           | $4,800          |
+| LIB                                         | LIB VIC                                                                            | $4,700          |
+| LIB                                         | ADD LIB                                                                            | $4,655          |
+| ALP                                         | ALP-SA: SA Progressive Business Inc.                                               | $4,560          |
+| LIB                                         | Lib-VIC                                                                            | $4,550          |
+| NP                                          | National Party of Australia - NAT-NSW                                              | $4,500          |
+| NP                                          | National Party QLD                                                                 | $4,500          |
+| NP                                          | NATS - FED                                                                         | $4,500          |
+| ALP                                         | Progressive Busine Association / ALP-VIC                                           | $4,400          |
+| LIB                                         | LIB-TAS Liberal Party of Australia (Tasmanian Division)                            | $4,400          |
+| LIB                                         | Liberal Party of Queensland / LNP-QLD                                              | $4,400          |
+| LIB                                         | Murray 250 Club                                                                    | $4,400          |
+| NP                                          | National Party NAT-NSW                                                             | $4,400          |
+| LIB                                         | Liberal Party of Australia, NSW Division/LIB-NSW                                   | $4,385          |
+| ALP                                         | Victorian ALP                                                                      | $4,354          |
+| ALP                                         | Labor Party of NSW                                                                 | $4,344          |
+| TMcGrane                                    | Tony McGrane                                                                       | $4,300          |
+| NP                                          | The Nationals - NSW                                                                | $4,204          |
+| LIB                                         | Hellenic 200 Club                                                                  | $4,200          |
+| Progressive                                 | Australian Progressive Alliance - SA                                               | $4,176          |
+| ALP                                         | Australian Labor Party - SA - ALP-SA                                               | $4,175          |
+| LIB                                         | Liberal Party of Australia (SA) LIB                                                | $4,150          |
+| LIB                                         | Liberal Party VIC                                                                  | $4,134          |
+| LIB                                         | Liberal Party VIC Division - Flinders                                              | $4,100          |
+| LIB                                         | LIB-VIC - Boardroom Policy Forum                                                   | $4,091          |
+| ALP                                         | Australian Labor Party - 2012 State Conference Business Observers/ALP-FED          | $4,050          |
+| DLP                                         | Democratic Socialist Electoral League                                              | $4,038          |
+| ALP                                         | ALP-Tasmania Bass (Geoff Lyons)                                                    | $4,000          |
+| ALP                                         | APL-QLD                                                                            | $4,000          |
+| ALP                                         | Australian Labor Party (QLD)/ALP-QLD                                               | $4,000          |
+| DEM                                         | Australian Democrats SA Division                                                   | $4,000          |
+| LIB                                         | Lib - Fed: Annual Gala Dinner                                                      | $4,000          |
+| LIB                                         | LIB-FED Liberal Party of Australia (Federal Secretariat)                           | $4,000          |
+| LIB                                         | LIB-NSW - LIberal Party of Aust. Paterson FEC                                      | $4,000          |
+| LIB                                         | LIB-SA (Carmen Garcia Campaign)                                                    | $4,000          |
+| LIB                                         | Liberal Party of Australia VIC Branch                                              | $4,000          |
+| LIB                                         | LNP Headquarters                                                                   | $4,000          |
+| LIB                                         | Pat Farmer/LIB-NSW                                                                 | $4,000          |
+| NP                                          | Nationals (NSW Fed a/c)                                                            | $4,000          |
+| NP                                          | Nationals Party                                                                    | $4,000          |
+| NP                                          | Young National Party of Australia - NATIONAL                                       | $4,000          |
+| ZSteggall                                   | Warringah Marginal Seats Fund                                                      | $4,000          |
+| ALP                                         | Progressive Labour Party - NATIONAL                                                | $3,986          |
+| LIB                                         | Liberal Party (NSW)                                                                | $3,950          |
+| LIB                                         | LIB-VIC Casey Federal Electorate Conference                                        | $3,890          |
+| LIB                                         | LIB-WA (500 Club)                                                                  | $3,880          |
+| ALP                                         | Progressive Bus. Assoc. - ALP-FED                                                  | $3,850          |
+| ALP                                         | ALP KINGSFORD SMITH ALP-NSW                                                        | $3,765          |
+| NP                                          | National Party of Australia - NAT                                                  | $3,760          |
+| LIB                                         | LIB-VIC Kooyong 200 Club                                                           | $3,750          |
+| Fed                                         | Australian Federation Party Western Australia                                      | $3,727          |
+| ALP                                         | ALP NSW McMahon FEC - ALP-NSW                                                      | $3,600          |
+| ALP                                         | ALP NSW Page Federal Campaign - ALP-NSW                                            | $3,600          |
+| LIB                                         | Liberal Party of Australia - Bennelong FEC                                         | $3,600          |
+| LIB                                         | Liberal Party of Australia - Tas Division                                          | $3,600          |
+| ALP                                         | Progressive Business - VIC - EFT                                                   | $3,514          |
+|                                             | The Aged and Disability Pensioners Party - VIC                                     | $3,500          |
+| ALP                                         | ALP (VIC) (Subscription to Progressive Business)                                   | $3,500          |
+| ALP                                         | Australian Labor Party (Victorian Division)                                        | $3,500          |
+| ALP                                         | SA Progressive Business Inc (ALP-SA)                                               | $3,500          |
+| LIB                                         | Enterprise 500 (Vic Lib)                                                           | $3,500          |
+| LIB                                         | Liberal Party SA - Norwood SEC                                                     | $3,500          |
+| LIB                                         | LPA WA Division - LIB-WA                                                           | $3,500          |
+| PReilly                                     | Pat Reilly                                                                         | $3,500          |
+| UAP                                         | LNP - unit Tennyson Ward                                                           | $3,500          |
+| LIB                                         | Platinum Circle - LPA QLD Division - LIB-QLD                                       | $3,490          |
+| ALP                                         | Australian Labor Party VIC                                                         | $3,427          |
+| LIB                                         | Liberal Party of Australia LIB-SA                                                  | $3,345          |
+| ALP                                         | ALP-NSW - ALP McMahon Federal Campaign                                             | $3,300          |
+| ALP                                         | Australian Labor Party - ALP-ACT                                                   | $3,300          |
+| ALP                                         | Progressive Business Association / ALP - VIC                                       | $3,300          |
+| LIB                                         | LNP-QLD - LNP Conference - Brisbane                                                | $3,300          |
+| LIB                                         | LIB-NSW (2014 Fed Budget Dinner)                                                   | $3,300          |
+| LIB                                         | LIB-TAS (Private Dinner - 30/08/13)                                                | $3,300          |
+| LIB                                         | LIB-VIC (Enterprise 500 - Vic Fed Election Launch)                                 | $3,300          |
+| LIB                                         | Liberal National Party - LNP-QLD                                                   | $3,300          |
+| LIB                                         | LNP - QLD (Q Forum business event subscription)                                    | $3,300          |
+| LIB                                         | Milennium Forum - LPA - LIB-VIC                                                    | $3,300          |
+| NP                                          | National Party of Australia - NSW / NAT-NSW                                        | $3,300          |
+| PHON                                        | Pauline Hanson's One Nation - NSW                                                  | $3,300          |
+| ALP                                         | Australian Labor Party ALP-NSW                                                     | $3,273          |
+| ALP                                         | Australian Labor Party - ALP-WA                                                    | $3,260          |
+| GRN                                         | GRN - WA                                                                           | $3,200          |
+| ALP                                         | Progressive Business Associate - State Budget Breakfast / ALP-VIC                  | $3,190          |
+| LIB                                         | Liberal Party of Australia - NSW / LIB-NSW                                         | $3,180          |
+| ALP                                         | Australian Labor Party (N.S.W. Branch)/ALP-NSW                                     | $3,150          |
+| LIB                                         | Liberal Party of Australia NSW Division - LIB-NSW                                  | $3,100          |
+| LIB                                         | The Warringah Club                                                                 | $3,100          |
+| LIB                                         | Paul Fletcher / LIB-FED                                                            | $3,083          |
+| ALP                                         | ALP NSW Branch - Grayndler                                                         | $3,007          |
+|                                             | Australian Reform Party - NATIONAL                                                 | $3,000          |
+|                                             | Melbourne SECC                                                                     | $3,000          |
+|                                             | Mitcham SECC                                                                       | $3,000          |
+|                                             | New England FRC Nat-Fed                                                            | $3,000          |
+|                                             | Ripon SECC                                                                         | $3,000          |
+|                                             | Seymour SECC                                                                       | $3,000          |
+|                                             | Wills FEA                                                                          | $3,000          |
+| ALP                                         | ALP NSW Branch - Deb O'Neill                                                       | $3,000          |
+| ALP                                         | ALP-NSW - Eden - Monaro Re - Election Campaign Federal Labor                       | $3,000          |
+| ALP                                         | ALP-NSW - NSW Branch Blaxland Federal Campaign                                     | $3,000          |
+| ALP                                         | Australian Labor NSW Branch Barton Federal Campaign - ALP-NSW                      | $3,000          |
+| ALP                                         | Australian Labor Party - Legacies and Gifts Ltd                                    | $3,000          |
+| ALP                                         | Australian Labor Party (South Australia)                                           | $3,000          |
+| ALP                                         | Dobell Federal Campaign (Australian Labor Party)                                   | $3,000          |
+| ALP                                         | Labor Party VIC                                                                    | $3,000          |
+| ALP                                         | PORTS RE-ELECTION/ALP-FED                                                          | $3,000          |
+| GetUp                                       | GetUp ltd                                                                          | $3,000          |
+| LIB                                         | LIB-FED: Budget Reply Luncheon                                                     | $3,000          |
+| LIB                                         | LIB-NSW (2013 Fed Campaign Dinner with Hon Tony Abbott)                            | $3,000          |
+| LIB                                         | LIB-VIC - Liberal Party Melbourne Victorian Division                               | $3,000          |
+| LIB                                         | LIB-WA Liberal Party (WA Divisin) Inc                                              | $3,000          |
+| LIB                                         | Liberal National Party of Queensland (LNP-QLD)                                     | $3,000          |
+| LIB                                         | Liberal Party - Benambra Electorate Council                                        | $3,000          |
+| LIB                                         | Liberal Party of Australia Dinner - A. J. Clark AM                                 | $3,000          |
+| LIB                                         | Liberal Party of Australia NSW Divison                                             | $3,000          |
+| LIB                                         | Liberal Party of Australia/LIB FED                                                 | $3,000          |
+| LIB                                         | Liberal Party Sydney SEC                                                           | $3,000          |
+| LIB                                         | Liberal Party VIC - Enterprise 500 Victoria                                        | $3,000          |
+| LIB                                         | Liberal Party VIC Division - Flinders                                              | $3,000          |
+| LIB                                         | LNP-Qld                                                                            | $3,000          |
+| LIB                                         | LNP-QLD - LNP Ryan Fund                                                            | $3,000          |
+| LIB                                         | STUART FEDERAL ELECTORATE/LIB-FED                                                  | $3,000          |
+| NP                                          | NAT-NSW - National Cowper Electorate Council                                       | $3,000          |
+| UAP                                         | United Trade & Labour Council of South Australia                                   | $3,000          |
+| LIB                                         | LIB-NSW Liberal Party of Australia NSW Division                                    | $2,920          |
+| LIB                                         | Liberal Party of Australia SA Division                                             | $2,908          |
+| ALP                                         | Aust Labor Party                                                                   | $2,900          |
+| ALP                                         | Country Labor Party - NSW                                                          | $2,900          |
+| LIB                                         | Higgins 200 Club LIB-VIC                                                           | $2,873          |
+| LIB                                         | Casey Business Briefing - LIB-VIC                                                  | $2,860          |
+|                                             | CLR-NSW                                                                            | $2,850          |
+| NP                                          | National Party of Australia (S.A.) Inc.                                            | $2,800          |
+| LIB                                         | Liberal Party of Australia - Cook FEC                                              | $2,743          |
+| NP                                          | Nationls (NSW)                                                                     | $2,727          |
+| LIB                                         | The Platinum Circle (LNP-QLD)                                                      | $2,700          |
+| ALP                                         | ALP New South Wales Branch/ALP-NSW                                                 | $2,690          |
+| ALP                                         | ALP - ACT Branch                                                                   | $2,682          |
+| ALP                                         | SA Progressive Business ALP-SA                                                     | $2,640          |
+| LIB                                         | Liberal Party of Australia Hindmarsh FEC LIB                                       | $2,600          |
+|                                             | Baulkham Hills SEC                                                                 | $2,500          |
+|                                             | The Bradfield Forum                                                                | $2,500          |
+|                                             | Wollondilly                                                                        | $2,500          |
+| ALP                                         | ALP - Fed: Federal Budget Night Dinner                                             | $2,500          |
+| ALP                                         | ALP (NSW Branch) Blaxland FCA - ALP-NSW                                            | $2,500          |
+| ALP                                         | Australian Labor Party - SA Progressive Business - ALP-SA                          | $2,500          |
+| ALP                                         | Fowler Federal Campaign Account - ALP-NSW                                          | $2,500          |
+| ALP                                         | Tasmanian Labor                                                                    | $2,500          |
+| DEM                                         | Australian Democrats - ACT Division                                                | $2,500          |
+| LIB                                         | Andrew Constance - LIB - NSW                                                       | $2,500          |
+| LIB                                         | Enterprise 500                                                                     | $2,500          |
+| LIB                                         | Higgins Electorate Conference - LIB-VIC                                            | $2,500          |
+| LIB                                         | LIB-VIC Menzies 200 Club                                                           | $2,500          |
+| LIB                                         | Liberal Party Australia LIB-FED                                                    | $2,500          |
+| LIB                                         | Liberal Party Geraldton                                                            | $2,500          |
+| LIB                                         | Liberal Party of Australia LNP-QLD                                                 | $2,500          |
+| LIB                                         | Liberal Party Wannon - LIB-VIC                                                     | $2,500          |
+| LIB                                         | LNP - Gladstone SEC                                                                | $2,500          |
+| LIB                                         | LNP - LNP Moreton FDC                                                              | $2,500          |
+| LIB                                         | LNP Mt Coot-tha SEC                                                                | $2,500          |
+| LIB                                         | Liberal Party of Australia - Victoria Division                                     | $2,450          |
+| LIB                                         | Liberal Party of Australia - LIB-NSW                                               | $2,320          |
+| LIB                                         | Liberal Party NSW Division - Paterson                                              | $2,300          |
+| LIB                                         | LIB-VIC - Evening brief - Hockey                                                   | $2,273          |
+| LIB                                         | Liberal Party VIC - Enterprise 500 Victoria                                        | $2,272          |
+| LIB                                         | ENTERPRISE VICTORIA/LIBERAL PARTY LIB-VIC                                          | $2,250          |
+| ALP                                         | ALP (VIC) (Dinner held by Progressive Business)                                    | $2,200          |
+| ALP                                         | ALP (VIC) (Dinnwe held by Progressive Business)                                    | $2,200          |
+| ALP                                         | ALP NSW Branch - Anthony Albanese                                                  | $2,200          |
+| ALP                                         | ALP-QLD - Queensland Party                                                         | $2,200          |
+| ALP                                         | Australian Labor Party (QLD) ALP                                                   | $2,200          |
+| ALP                                         | Australian Labor Party (Victorian Branch) (paid to Progressive Business)           | $2,200          |
+| ALP                                         | Australian Labor Party NSW Branch Federal Capaign Account - ALP-NSW                | $2,200          |
+| ALP                                         | Austrlaian Labor Party                                                             | $2,200          |
+| DLP                                         | Democratic Labor Party (DLP) - Queensland Branch                                   | $2,200          |
+| LIB                                         | Casey Business Briefing Club Melbourne - LIB-VIC                                   | $2,200          |
+| LIB                                         | LIB-TAS - Tasmanian Division                                                       | $2,200          |
+| LIB                                         | Liberal Party of Australia - Citizen Din                                           | $2,200          |
+| LIB                                         | Liberal Party of Australia - NSW LIB-NSW                                           | $2,200          |
+| LIB                                         | LNP-QLD - Function 18/12/13                                                        | $2,200          |
+| ALP                                         | Progressive Business - VIC-EFT                                                     | $2,199          |
+| ALP                                         | Catering for ALP Lunch                                                             | $2,188          |
+| ALP                                         | Sheraton on the Park - Plibersek function - ALP                                    | $2,167          |
+| LIB                                         | Liberal Party of Australia (S.A. Division) / LIB-SA                                | $2,150          |
+| ALP                                         | ALP Bruce FEA                                                                      | $2,145          |
+| ALP                                         | ALP-VIC - Australian Labor Party (Victorian Branch)                                | $2,100          |
+| LIB                                         | Liberal Party of Aust                                                              | $2,100          |
+| LIB                                         | Liberal Party of Australia NSW Division - Bega                                     | $2,100          |
+| LIB                                         | Liberal Party of Australia NSW Division - Mackellar                                | $2,100          |
+| LIB                                         | LPA NSW Division - LIB-NSW                                                         | $2,080          |
+|                                             | Australia First Party - NATIONAL                                                   | $2,000          |
+|                                             | Ballarat Election Campaign                                                         | $2,000          |
+|                                             | Barton & Hughes Fedrral Campaign Account. (Joint)                                  | $2,000          |
+|                                             | Forrest Campaign Account                                                           | $2,000          |
+|                                             | Greek Aust Conservative Coalition                                                  | $2,000          |
+|                                             | Holland Park MEC                                                                   | $2,000          |
+|                                             | Kogarah                                                                            | $2,000          |
+|                                             | Mayo Federal Electorate Convention                                                 | $2,000          |
+|                                             | Nuclear Disarmament Party of Australia - NATIONAL                                  | $2,000          |
+|                                             | Robert Oakshott                                                                    | $2,000          |
+| ALP                                         | ALP - FED (Business event with Shadow Ministers)                                   | $2,000          |
+| ALP                                         | ALP - Parkes (Andrew Brooks)(ALP-NSW)                                              | $2,000          |
+| ALP                                         | ALP (2014 Fed Budget Reply Dinner)                                                 | $2,000          |
+| ALP                                         | ALP (NSW Branch) Bennelong Campaign                                                | $2,000          |
+| ALP                                         | ALP FEC LILLEY ALP-QLD                                                             | $2,000          |
+| ALP                                         | ALP NSW Branch - Chris Hayes                                                       | $2,000          |
+| ALP                                         | ALP NSW Branch - Tanya Plibersek                                                   | $2,000          |
+| ALP                                         | ALP WA (Stephen Smith)                                                             | $2,000          |
+| ALP                                         | ALP- NSW - Hunter Federal Campaign                                                 | $2,000          |
+| ALP                                         | ALP-NSW - Fowler Federal Campaign Account                                          | $2,000          |
+| ALP                                         | ALP-QLD - Ipswich                                                                  | $2,000          |
+| ALP                                         | ALP-WA - Swan (Tim Hammond)                                                        | $2,000          |
+| ALP                                         | Australian Labor Party - ALP - (NSW Federal Campaign Account)                      | $2,000          |
+| ALP                                         | Australian Labor Party - NSW - ALP-NSW                                             | $2,000          |
+| ALP                                         | Australian Labor Party (South Australian Branch) (ALP-SA)                          | $2,000          |
+| ALP                                         | Ballarat Election Campaign / ALP-VIC                                               | $2,000          |
+| ALP                                         | Ballarat FEA / ALP-VIC                                                             | $2,000          |
+| ALP                                         | Federal ALP                                                                        | $2,000          |
+| ALP                                         | Gary Gray ALP Brand Campaign Account                                               | $2,000          |
+| ALP                                         | Labor Business Roundtable / ALP-WA                                                 | $2,000          |
+| ALP                                         | Victorian Labor / ALP-VIC                                                          | $2,000          |
+| GRN                                         | Jamie Parker Greens for Balmain                                                    | $2,000          |
+| GRN                                         | The ACT Greens - ACT                                                               | $2,000          |
+| GRN                                         | The Greens (Inner Sydney Branch)                                                   | $2,000          |
+| LIB                                         | LNP-QLD - Forward Brisbane Leadership                                              | $2,000          |
+| LIB                                         | Australian Liberal Party                                                           | $2,000          |
+| LIB                                         | Casey FEC (Libs Fed)                                                               | $2,000          |
+| LIB                                         | Cowper Electorate Council - LIB-NSW                                                | $2,000          |
+| LIB                                         | LIB - NSW (Business event with Minister)                                           | $2,000          |
+| LIB                                         | Lib - Qld: Tim Mander Dinner                                                       | $2,000          |
+| LIB                                         | LIB -VIC Liberal Party of Australia (Victorian Division)                           | $2,000          |
+| LIB                                         | LIB-QLD: Done Doing Can Do Dinner                                                  | $2,000          |
+| LIB                                         | LIB-VIC - Annual Dinner 2012                                                       | $2,000          |
+| LIB                                         | LIB-VIC (The Higgins Federal Electorate Conference)                                | $2,000          |
+| LIB                                         | LIB-VIC Liberal Party of Victoria (Victorian Division)                             | $2,000          |
+| LIB                                         | Lib-WA Federal Campaign                                                            | $2,000          |
+| LIB                                         | Liberal Party - VIC Division                                                       | $2,000          |
+| LIB                                         | Liberal Party NSW Division - Paterson                                              | $2,000          |
+| LIB                                         | Liberal Party of Australia - SA Division (Mayo FEC)                                | $2,000          |
+| LIB                                         | Liberal Party of Australia (Tas Branch)                                            | $2,000          |
+| LIB                                         | Liberal Party of Australia (VIC Division) (paid to Higgins 200 Club)               | $2,000          |
+| LIB                                         | Liberal Party of Australia (Victorian Division) Lib VIC                            | $2,000          |
+| LIB                                         | Liberal Party Tasmania                                                             | $2,000          |
+| LIB                                         | Liberal Party WA - Mt Lawley Campaign                                              | $2,000          |
+| LIB                                         | LNP - Bowman                                                                       | $2,000          |
+| LIB                                         | LNP - Team Quirk LNP                                                               | $2,000          |
+| LIB                                         | LNP Bonner FDC - LIB-NSW                                                           | $2,000          |
+| LIB                                         | LNP Mansfield (LNP QLD)                                                            | $2,000          |
+| LIB                                         | LNP WIDE BAY                                                                       | $2,000          |
+| LIB                                         | LNP Wide Bay FDC                                                                   | $2,000          |
+| LIB                                         | LNP-QLD - Oxley FDC (federal fundraising)                                          | $2,000          |
+| LIB                                         | LNP-QLD - Prentice                                                                 | $2,000          |
+| LIB                                         | LPA SA Division                                                                    | $2,000          |
+| LIB                                         | NSW Liberal Women's Forum A/C                                                      | $2,000          |
+| LIB                                         | Platinum Circle - LIB-QLD                                                          | $2,000          |
+| LIB                                         | Platinum Circle - Liberal National Party                                           | $2,000          |
+| LIB                                         | Richmond FEC                                                                       | $2,000          |
+| LIB                                         | Warringah Club                                                                     | $2,000          |
+| NP                                          | National Party of Australia (SA) Inc                                               | $2,000          |
+| NP                                          | R Sutton (Nats WA)                                                                 | $2,000          |
+| SA                                          | Socialist Alliance - NSW                                                           | $2,000          |
+| ALP                                         | Australian Labor Party ACT Branch                                                  | $1,999          |
+| LIB                                         | Lib - Fed                                                                          | $1,999          |
+| ALP                                         | ALP-ACT: Dinner w/ Bill Shorten ACT Legislative Assembly                           | $1,980          |
+| ALP                                         | Progressive Business ALP-VIC                                                       | $1,980          |
+| ALP                                         | Progressive Business Association - ALP-VIC                                         | $1,980          |
+| CFMEU                                       | Construction Forestry Mining & Energy Indust. Union of Emp. QLD                    | $1,946          |
+| PHON                                        | ONA - FED                                                                          | $1,946          |
+| VECCI                                       | Victorian Employers' Chamber of Commerce & Industry                                | $1,909          |
+| ALP                                         | ALP NSW Branch - Grenville Campaign                                                | $1,900          |
+| CEC                                         | CED-Fed                                                                            | $1,900          |
+| LIB                                         | Lib - ACT: Event at Parliament House                                               | $1,900          |
+| LIB                                         | Lib - QLD: Queensland State Budget Lunch                                           | $1,900          |
+| LIB                                         | Lib - QLD: Tim Mander/Bronwyn Bishop Dinner                                        | $1,900          |
+| LIB                                         | LNP-QLD - Policy Discussion - State Budget 2014                                    | $1,900          |
+| PHON                                        | Pauline Hanson's One Nation - Western Australia                                    | $1,900          |
+| ALP                                         | ALP-VIC John Brumby                                                                | $1,898          |
+|                                             | NBLF on Sustainable Development                                                    | $1,855          |
+| LIB                                         | Liberal Party of Australia - Bradfield FEC                                         | $1,820          |
+| LIB                                         | LIB-VIC - Boardroom Dinner Hockey                                                  | $1,818          |
+| LIB                                         | Liberal Party of Australia - SA Division                                           | $1,818          |
+| ALP                                         | Kevin Rudd                                                                         | $1,800          |
+| ALP                                         | Michael Danby MHR, Federal Member for Melb. Ports                                  | $1,750          |
+| ALP                                         | ALP-ACT: Briefing with The Hon. Julia Gillard                                      | $1,750          |
+| LIB                                         | LIB-VIC Monash Club                                                                | $1,740          |
+| ALP                                         | Catering ALP for Lunch                                                             | $1,718          |
+|                                             | Queensland Research Pty Ltd                                                        | $1,700          |
+| ALP                                         | ALP-NSW - Lindsay FEC                                                              | $1,700          |
+| ALP                                         | Australian Labor Party - NSW - Wollondilly State Campaign                          | $1,700          |
+| ALP                                         | Australian Labor Party (N.S.W. Branch) / ALP-NSW                                   | $1,700          |
+| ALP                                         | Lindsay FEC - ALP-NSW                                                              | $1,700          |
+| LDP                                         | Liberal Democratic Party (NSW Branch)                                              | $1,700          |
+| LIB                                         | LIB-SA (Rachel Anderson's Adelaide SEC Business Breakfast 11/02/14)                | $1,700          |
+| ALP                                         | Progressive Business Post Budget Boardroom Lunch                                   | $1,699          |
+| ALP                                         | Sheraton on the Park - Bradbury function - ALP                                     | $1,673          |
+| ALP                                         | ALP (Fed)                                                                          | $1,650          |
+| ALP                                         | ALP VIC Division - ALP-VIC                                                         | $1,650          |
+| ALP                                         | Australian Labor Party (N.S.W. branch)                                             | $1,650          |
+| LIB                                         | Liberal Party of Aust Tasmanian Divisn                                             | $1,650          |
+| LIB                                         | Liberal Party of Australia (TAS) - LIB-TAS                                         | $1,650          |
+| LIB                                         | LNP - QLD (Business policy briefing event)                                         | $1,650          |
+| LIB                                         | LNP-QLD - Q Forum Women of Influence Series                                        | $1,650          |
+| LIB                                         | Milennium Forum                                                                    | $1,650          |
+| ALP                                         | ALP NSW Branch - Susan Templeman                                                   | $1,600          |
+| ALP                                         | Labor Business Roundtable                                                          | $1,600          |
+| LIB                                         | VIC-LIB Dunkley Electorate Conference                                              | $1,600          |
+| ALP                                         | Australian Labor Party - VIC - ALP-VIC                                             | $1,550          |
+| LIB                                         | LNP-QLD (Sportsman's Lunch 2014)                                                   | $1,550          |
+| ALP                                         | Australian Labor Party - SA                                                        | $1,540          |
+| NP                                          | Melinda Pavey - NAT - NSW                                                          | $1,540          |
+|                                             | Bundoora SECC                                                                      | $1,500          |
+|                                             | Londonderry                                                                        | $1,500          |
+|                                             | Non-Custodial Parents Party - NATIONAL                                             | $1,500          |
+| ALP                                         | ALP - FED                                                                          | $1,500          |
+| ALP                                         | ALP Australian Labor Party National Secretariat                                    | $1,500          |
+| ALP                                         | ALP NSW (Hunter) - ALP-NSW                                                         | $1,500          |
+| ALP                                         | ALP NSW Branch - Jason Clare                                                       | $1,500          |
+| ALP                                         | Australian Labor Party - (Victorian Division)                                      | $1,500          |
+| ALP                                         | Australian Labor Party (Western Australian Branch) / ALP-WA                        | $1,500          |
+| ALP                                         | Infrastructure Business Forum / ALP-ACT                                            | $1,500          |
+| ALP                                         | Prospect FEC - ALP-FED                                                             | $1,500          |
+| ALP                                         | Senator Glen Sterle Campaign Account/ ALP-FED                                      | $1,500          |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) QLD                                   | $1,500          |
+| ChristDem                                   | Christian Democratic Party (Fred Nile Group) WA                                    | $1,500          |
+| DEM                                         | Australian Democrats - QLD Division Inc                                            | $1,500          |
+| LIB                                         | Bass 200 Club                                                                      | $1,500          |
+| LIB                                         | Friends of Barry O'Farrell                                                         | $1,500          |
+| LIB                                         | Bradfield Conference / LIB-NSW                                                     | $1,500          |
+| LIB                                         | LIB - NSW (Federal Budget event)                                                   | $1,500          |
+| LIB                                         | Lib - VIC: Boardroom Policy Forum                                                  | $1,500          |
+| LIB                                         | LIB (VIC) (Business Dinner Forum)                                                  | $1,500          |
+| LIB                                         | Lib-FED Liberal Party of Australia                                                 | $1,500          |
+| LIB                                         | LIB-SA (David Ridgeway's Port Lincoln Swim with Tuna)                              | $1,500          |
+| LIB                                         | LIB-VIC - Liberal Party Melbourne Vic                                              | $1,500          |
+| LIB                                         | LIB-WA - Dinner Cormann                                                            | $1,500          |
+| LIB                                         | Liberal National Party QLD/LNP-QLD                                                 | $1,500          |
+| LIB                                         | Liberal Party NSW (LIB-NSW)                                                        | $1,500          |
+| LIB                                         | Liberal Party NSW Division - Hawkesbury                                            | $1,500          |
+| LIB                                         | Liberal Party NSW Division - Mackellar                                             | $1,500          |
+| LIB                                         | Liberal Party NSW DIvision - Manly                                                 | $1,500          |
+| LIB                                         | Liberal Party NSW Division - Wakehurst                                             | $1,500          |
+| LIB                                         | Liberal Party of Australia - NSW Division State Electorate Conference              | $1,500          |
+| LIB                                         | Liberal Party of Australia (NSW Division - Wollondilly SEC)                        | $1,500          |
+| LIB                                         | LNP Maranora Divisional Council/LNP-QLD                                            | $1,500          |
+| LIB                                         | LPA - SA Divison - LIB-SA                                                          | $1,500          |
+| LIB                                         | Young Liberal Movement of Australia                                                | $1,500          |
+| NP                                          | National Party of Australia NSW Federal Campaign - NAT-NSW                         | $1,500          |
+| PHON                                        | Pauline Hanson's One Nation - SA                                                   | $1,500          |
+| ALP                                         | ALP - ACT                                                                          | $1,490          |
+| ALP                                         | ALP-VIC - Tim Holding                                                              | $1,471          |
+| LIB                                         | Liberal Party of Australia SA                                                      | $1,453          |
+| LIB                                         | LIB-VIC: Monash Club Dinner - Hon. T Abbott                                        | $1,450          |
+| ALP                                         | ALP-VIC Tim Pallas                                                                 | $1,440          |
+| UAP                                         | LNP - unit Ashgrove                                                                | $1,430          |
+| ALP                                         | Doltone House - Combet lunch - ALP                                                 | $1,416          |
+| ALP                                         | ALP Vic Branch                                                                     | $1,400          |
+| ALP                                         | ALP - Boardroom Dinner Bill Shorten                                                | $1,364          |
+| LIB                                         | LIB-VIC - Boardroom Dinner Robb                                                    | $1,364          |
+| LIB                                         | LIB-VIC - Enterprise 500 Vic                                                       | $1,364          |
+| ALP                                         | ALP National Sectretariat                                                          | $1,363          |
+| DLP                                         | Democratic Labour Party - WA Branch                                                | $1,363          |
+| ALP                                         | ALP NSW Branch - Grayndler Campaign                                                | $1,360          |
+| NP                                          | The Nationals for Regional Aust.                                                   | $1,350          |
+| ALP                                         | Australian Labor Party ACT                                                         | $1,315          |
+| LIB                                         | Kooyong 200                                                                        | $1,300          |
+| LIB                                         | Liberal Party - LIB TAS                                                            | $1,300          |
+| LIB                                         | National Liberal Australia                                                         | $1,300          |
+| LIB                                         | Five Hundred Club - 2010 Annual Post Budget Breakfast - LIB-VIC                    | $1,281          |
+| LIB                                         | Lib - VIC: Annual State Post Budget Breakfast                                      | $1,275          |
+| LIB                                         | The Liberal Party of Australia (Victoria Division) LIB-VIC                         | $1,263          |
+| ALP                                         | ALP NSW Branch Blaxland Federal Campaign - ALP-NSW                                 | $1,250          |
+| LIB                                         | Liberal Party of Australia/LIB-VIC                                                 | $1,250          |
+| NP                                          | National Party of Victoria (NAT-VIC)                                               | $1,250          |
+| ALP                                         | ALP - WA (Business event)                                                          | $1,232          |
+| ALP                                         | ALP-TAS (M O'Byrne)                                                                | $1,200          |
+| ALP                                         | SA-ALP                                                                             | $1,200          |
+| LIB                                         | LIB (The Platinum Circle Dinner)                                                   | $1,200          |
+| LIB                                         | LIB-VIC Dunkley Flinders Events                                                    | $1,200          |
+| LIB                                         | Platinum Circle (LNP-QLD)                                                          | $1,200          |
+| LIB                                         | VIC-LIB Higgins 200 Club                                                           | $1,200          |
+| NP                                          | NAT - National Budget                                                              | $1,200          |
+| ALP                                         | ALP VIC Branch                                                                     | $1,150          |
+| ALP                                         | Progressive Business Association - Corporate Membership                            | $1,150          |
+| ALP                                         | ALP-VIC - Labor Party dinner                                                       | $1,125          |
+|                                             | Hughes Federal Campaign Account                                                    | $1,100          |
+|                                             | The Endeavour Consulting Group                                                     | $1,100          |
+| ALP                                         | Clarence Campaign (The Hon Craig Knowles)                                          | $1,100          |
+| ALP                                         | ALP - FED (Federal Budget reply event)                                             | $1,100          |
+| ALP                                         | ALP (National Secretariat - Gary Gray Event on 07/07/2014)                         | $1,100          |
+| ALP                                         | ALP (Sub-continental group) (NSW Branch)                                           | $1,100          |
+| ALP                                         | ALP-VIC (progressive business)                                                     | $1,100          |
+| ALP                                         | Australian Labor Party NSW Branch function                                         | $1,100          |
+| LIB                                         | Higgins 200 Club (LIB-FED)                                                         | $1,100          |
+| LIB                                         | Higgins Electorate (Fed Lib)                                                       | $1,100          |
+| LIB                                         | Lib - Qld: Federal Budget Reply Lunch                                              | $1,100          |
+| LIB                                         | LIB- VIC                                                                           | $1,100          |
+| LIB                                         | Lib-Vic Federal Campaign - VIC                                                     | $1,100          |
+| LIB                                         | Liberal Party of Australia - Senator Mathias Cormann                               | $1,100          |
+| LIB                                         | Liberal Party of Australia NSW Div                                                 | $1,100          |
+| NP                                          | National Party of Australia - VIC Branch                                           | $1,100          |
+| NP                                          | Nationals (Vic)                                                                    | $1,100          |
+| LIB                                         | Endeavour Business Forum / LIB-NSW                                                 | $1,050          |
+| LIB                                         | Liberal Party NSW Division - Cook                                                  | $1,050          |
+|                                             | Brett Murray                                                                       | $1,000          |
+|                                             | Chesterfield Evans                                                                 | $1,000          |
+|                                             | Lang Holdings Aust Pty Ltd                                                         | $1,000          |
+|                                             | Marrickville State Campaign                                                        | $1,000          |
+|                                             | Max Christmas Camp                                                                 | $1,000          |
+| ALP                                         | ALP QLD Branch - Brisbane                                                          | $1,000          |
+| ALP                                         | ALP - National Secretariat (2014 Fed Budget Reply)                                 | $1,000          |
+| ALP                                         | ALP (ALP QLD)                                                                      | $1,000          |
+| ALP                                         | ALP (FED)                                                                          | $1,000          |
+| ALP                                         | ALP (NSW Branch) EFT                                                               | $1,000          |
+| ALP                                         | ALP (NSW) Branch Bennelong Fed Campaig                                             | $1,000          |
+| ALP                                         | ALP Kogarah Campaign Account                                                       | $1,000          |
+| ALP                                         | ALP NSW Branch - Granville                                                         | $1,000          |
+| ALP                                         | ALP NSW Branch - Maroubra                                                          | $1,000          |
+| ALP                                         | ALP NSW Branch - McMahon                                                           | $1,000          |
+| ALP                                         | ALP NSW Branch - Sen. Matt Thistlethwaite                                          | $1,000          |
+| ALP                                         | ALP NSW Branch - Tony Burke                                                        | $1,000          |
+| ALP                                         | ALP NSW Branch - Watson                                                            | $1,000          |
+| ALP                                         | ALP NSW Warringah (Hugh Zochling)                                                  | $1,000          |
+| ALP                                         | ALP QLD Branch - Inala                                                             | $1,000          |
+| ALP                                         | ALP- WA                                                                            | $1,000          |
+| ALP                                         | ALP-TAS (Bacon)                                                                    | $1,000          |
+| ALP                                         | ALP-VIC / Australian Labor Party - VIC                                             | $1,000          |
+| ALP                                         | Aust. Labour Party                                                                 | $1,000          |
+| ALP                                         | Australian Labor Party - Everton Campaign                                          | $1,000          |
+| ALP                                         | Australian Labor Party - WA/ALP - WA                                               | $1,000          |
+| ALP                                         | Australian Labor Party / ALP-WA                                                    | $1,000          |
+| ALP                                         | Australian Labor Party ALP-VIC                                                     | $1,000          |
+| ALP                                         | Australian Labour Party NSW Branch                                                 | $1,000          |
+| ALP                                         | Frankston SECC / ALP-VIC                                                           | $1,000          |
+| ALP                                         | Joel Fitzgibbon, Member for Hunter/ALP                                             | $1,000          |
+| ALP                                         | Michael Danby's Re-Election - ALP - Vic                                            | $1,000          |
+| ALP                                         | QLD Growth Management Summit Dinner / ALP-QLD                                      | $1,000          |
+| DEM                                         | Australian Democrats - VIC Division                                                | $1,000          |
+| LDP                                         | Liberal Democratic Party (ACT Branch)                                              | $1,000          |
+| LIB                                         | LNP - Brisbane FDC                                                                 | $1,000          |
+| LIB                                         | Forward Brisbane Leadership - LNP QLD                                              | $1,000          |
+| LIB                                         | LNP-QLD Brisbane FDC                                                               | $1,000          |
+| LIB                                         | Aston Electoral Office - LIB-NSW                                                   | $1,000          |
+| LIB                                         | Bayswater Electorate Conference - LIB - Vic                                        | $1,000          |
+| LIB                                         | Bradfield Forum Lindfield - LIB-NSW                                                | $1,000          |
+| LIB                                         | Canning Liberal Campaign                                                           | $1,000          |
+| LIB                                         | Dunkley Fec (Fed Lib)                                                              | $1,000          |
+| LIB                                         | Higgins Electorate Conference - LIB-FED                                            | $1,000          |
+| LIB                                         | Karawatha LNP Campaign (LNP QLD)                                                   | $1,000          |
+| LIB                                         | Lib - NSW: Federal Budget Reply Dinner                                             | $1,000          |
+| LIB                                         | LIB - VIC (Higgins FEC)                                                            | $1,000          |
+| LIB                                         | Lib - VIC: Budget Week Cocktail Party                                              | $1,000          |
+| LIB                                         | LIB-NSW - LIberal Party NSW Bradfield FEC                                          | $1,000          |
+| LIB                                         | LIB-QLD Dickson Account                                                            | $1,000          |
+| LIB                                         | LIB-SA - Sturt FEC                                                                 | $1,000          |
+| LIB                                         | LIB-TAS Liberal Party of Australia – Tasmanian Division                            | $1,000          |
+| LIB                                         | Lib-Vic                                                                            | $1,000          |
+| LIB                                         | LIB-WA                                                                             | $1,000          |
+| LIB                                         | Liberal National Party - Moncrieff                                                 | $1,000          |
+| LIB                                         | Liberal Part of Australia SA Division - Dunstan                                    | $1,000          |
+| LIB                                         | Liberal Party - LIB NSW                                                            | $1,000          |
+| LIB                                         | Liberal Party - Tony Abbott's Warringah 1000 Forum                                 | $1,000          |
+| LIB                                         | Liberal Party (Ashford SEC)                                                        | $1,000          |
+| LIB                                         | Liberal Party Australia/LIB-FED                                                    | $1,000          |
+| LIB                                         | Liberal Party Federal Campaign Assistance Programme                                | $1,000          |
+| LIB                                         | Liberal Party NSW Division - North Sydney FEC                                      | $1,000          |
+| LIB                                         | Liberal Party NSW Division - Penrith                                               | $1,000          |
+| LIB                                         | Liberal Party NSW Division (Macarthur)                                             | $1,000          |
+| LIB                                         | Liberal Party of Australia - Casey Federal Electorate                              | $1,000          |
+| LIB                                         | Liberal Party of Australia - SA Fisher SEC                                         | $1,000          |
+| LIB                                         | Liberal Party of Australia (News South Wales Division) (LIB-NSW)                   | $1,000          |
+| LIB                                         | LNP - Samford Qld                                                                  | $1,000          |
+| LIB                                         | LNP Fairfax DC                                                                     | $1,000          |
+| LIB                                         | LNP Macgregor Ward Campaign (LNP QLD)                                              | $1,000          |
+| LIB                                         | LNP Sunnybank                                                                      | $1,000          |
+| LIB                                         | LNP Toowoomba North                                                                | $1,000          |
+| LIB                                         | LNP-QLD - Ryan FDC (federal fundraising)                                           | $1,000          |
+| LIB                                         | LNP/Dickson                                                                        | $1,000          |
+| LIB                                         | LPA - Mayo Federal Electorate - LIB-SA                                             | $1,000          |
+| LIB                                         | LPA - NSW Division - LIB-NSW                                                       | $1,000          |
+| LIB                                         | NSW Liberal Party (NSW Division)                                                   | $1,000          |
+| LIB                                         | Rankin FEC                                                                         | $1,000          |
+| LIB                                         | Warringah Federal Electorate Conference                                            | $1,000          |
+| LIB                                         | Young Liberal Movement                                                             | $1,000          |
+| NP                                          | NAT - VIC                                                                          | $1,000          |
+| PHON                                        | Pauline Hanson's One Nation - WA                                                   | $1,000          |
+| ALP                                         | ACT Labor - ALP-ACT                                                                | $990            |
+| ALP                                         | ALP - Vic                                                                          | $990            |
+| ALP                                         | ALP NSW Branch - Dinner with P.M.                                                  | $990            |
+| ALP                                         | Australian Labor party (Victoria)                                                  | $990            |
+| ALP                                         | Labor Party SA                                                                     | $990            |
+| LIB                                         | LIB - WA (500 Club)                                                                | $990            |
+| LIB                                         | Liberal Party NSW Division - Willoughby                                            | $990            |
+| LIB                                         | LNP - QLD (Business event with Shadow Minister)                                    | $990            |
+| LIB                                         | VIC-LIB Kooyong 200 Club                                                           | $990            |
+| NP                                          | NAT (Budget Speech Drinks 13/5/14)                                                 | $990            |
+| LIB                                         | Casey federal Electorate - LIB-VIC                                                 | $950            |
+| ALP                                         | Progressive Business Assoc.                                                        | $934            |
+| ALP                                         | ALP-NSW - Shadow Ministry Lunch 30 Nov 2012 (Fed campaign)                         | $909            |
+| LIB                                         | Liberal Party of Australia - QLD                                                   | $909            |
+| NP                                          | NAT-NSW - Boardroom Lunch (Fed Campaign)                                           | $909            |
+|                                             | Granville                                                                          | $900            |
+| ALP                                         | ALP NSW Branch - David Bradbury                                                    | $900            |
+| ALP                                         | SA Progressive Business (ALP-SA)                                                   | $900            |
+| ALP                                         | Progressive Business - Annual Dinner                                               | $895            |
+| LIB                                         | Bradfield Forum (Liberal Party of Australia)                                       | $850            |
+| LIB                                         | LIB-VIC Dunkley Blue Ribbon Club                                                   | $850            |
+| ALP                                         | Victoria Trades Hall                                                               | $840            |
+| LIB                                         | LIB-VIC                                                                            | $825            |
+| LIB                                         | LNP - QLD (Q Forum business event)                                                 | $825            |
+| LIB                                         | LNP/Karawatha                                                                      | $825            |
+| LIB                                         | Willoughby Sec - Liberal Party                                                     | $810            |
+| LIB                                         | Liberal Party of Australia - WA Branch                                             | $803            |
+|                                             | Keira                                                                              | $800            |
+|                                             | North Sydney FEC                                                                   | $800            |
+| LIB                                         | Liberal Party Australia - NSW - LIB-NSW                                            | $785            |
+| LIB                                         | Liberal Party of Australia - TAS LIB-TAS                                           | $770            |
+| LIB                                         | Liberal Party of Australia (Tas Division)                                          | $770            |
+| NP                                          | NAT-FED - National Party of Australia Federal Campaign                             | $770            |
+|                                             | Duncan Gay - NAT - NSW                                                             | $750            |
+| ALP                                         | ALP NSW Branch - Marrickville                                                      | $750            |
+| ALP                                         | ALP NT - Wanguni                                                                   | $750            |
+| ALP                                         | ALP WA - Rockingham                                                                | $750            |
+| ALP                                         | ALP-SA (Kaurna Fundraiser 23/1/14)                                                 | $750            |
+| LIB                                         | LIB-SA (Boothby FEC)                                                               | $750            |
+| LIB                                         | Liberal Party - Berowra FEC                                                        | $750            |
+| LIB                                         | Liberal Party VIC Division                                                         | $750            |
+| NP                                          | National Party (WA) Inc                                                            | $750            |
+| ALP                                         | Australian Labor Party - QLD - ALP-QLD                                             | $740            |
+| LIB                                         | LIB-VIC - Raffle Tickets                                                           | $728            |
+| ZSteggall                                   | warringah independent                                                              | $725            |
+| ALP                                         | ALP NSW Branch - Christina Keneally Dinner                                         | $700            |
+| ALP                                         | ALP NSW Branch - Laurie Ferguson                                                   | $700            |
+| ALP                                         | ALP-SA (SA Progressive Dinner 20/11/13)                                            | $700            |
+| LIB                                         | Liberal Party of Australia - NSW - LIB-NSW                                         | $700            |
+| LIB                                         | Liberal Party Tasmania Division                                                    | $700            |
+| LIB                                         | Liberal Party NSW Division - North Sydney                                          | $681            |
+| ALP                                         | Mark Bishop ALP Senate Campaign Committee Account                                  | $660            |
+| DLP                                         | Democratic Labor Party (DLP) - WA Branch                                           | $660            |
+| LIB                                         | LIB (Bayside Forum Annual Dinner)                                                  | $660            |
+| NP                                          | National Party of Australia - VIC - NAT-VIC                                        | $660            |
+| CLP                                         | CLP-NT - Solomon Federal Acct                                                      | $650            |
+| LIB                                         | Liberal Party of Australia (Lib-FED) (Bradfield Forum)                             | $640            |
+| ALP                                         | ALP - Robert McClelland Campaign - ALP-NSW                                         | $600            |
+| ALP                                         | ALP NSW Branch - Sub. Cont. Friends of Labour                                      | $600            |
+| ALP                                         | ALP-QLD: Cocktail Party Hon. Andrew Fraser MP                                      | $600            |
+| ALP                                         | Australia Labor Party - SA - ALP-SA                                                | $600            |
+| LIB                                         | Bill Glasson FDC, Liberal National Party / LNP-QLD                                 | $600            |
+| LIB                                         | Lib - NSW: Parramatta Campaign Launch Dinner                                       | $600            |
+| NP                                          | National Party of Australia/NAT-FED                                                | $600            |
+| LIB                                         | Liberal Party - Isobel Redmond / LIB-SA                                            | $570            |
+|                                             | Bradfield Forum                                                                    | $550            |
+|                                             | Endeavour Business Forum                                                           | $550            |
+| ALP                                         | ALP-FED Labor Business Forum                                                       | $550            |
+| ALP                                         | Australian Labor Party NT ALP-NT                                                   | $550            |
+| LIB                                         | Liberal Party Federal /LIB                                                         | $550            |
+| LIB                                         | Liberal Party of Australia (Tasmanian Division)                                    | $550            |
+| LIB                                         | LPA NSW Division                                                                   | $550            |
+| ALP                                         | Progressive Business - State Budget Breakfast                                      | $539            |
+|                                             | Andrew Fraser - NAT - NSW                                                          | $500            |
+|                                             | Cook Endeavour Forum                                                               | $500            |
+|                                             | Daryl Williams                                                                     | $500            |
+|                                             | Gippsland TLC                                                                      | $500            |
+|                                             | Helen Coonan                                                                       | $500            |
+|                                             | North Sydney FEC Campaign Fund                                                     | $500            |
+|                                             | Salvatore Scevola                                                                  | $500            |
+| ALP                                         | ALP QLD - South Brisbane                                                           | $500            |
+| ALP                                         | ALP La Trobe - ALP-VIC                                                             | $500            |
+| ALP                                         | ALP NSW Branch - Greenway                                                          | $500            |
+| ALP                                         | ALP NSW Branch - McKell Dinner                                                     | $500            |
+| ALP                                         | ALP QLD - Mulgrave                                                                 | $500            |
+| ALP                                         | ALP Vic Branch - Lyndhurst                                                         | $500            |
+| ALP                                         | ALP Western Metro Region                                                           | $500            |
+| ALP                                         | ALP-SA (ALP Adelaide Lunch 12/2/14)                                                | $500            |
+| ALP                                         | ALP-SA (Campaign Insight Dinner)                                                   | $500            |
+| ALP                                         | Australian Labor Party (ALP) - (South Australian Branch)                           | $500            |
+| ALP                                         | Country Labor                                                                      | $500            |
+| DEM                                         | Australian Democrats - TAS Division                                                | $500            |
+| LIB                                         | Federal Electorate of Sydney - Sydney FEC                                          | $500            |
+| LIB                                         | Lib - NSW: 2013 Federal Budget Reply Dinner                                        | $500            |
+| LIB                                         | Lib - Vic: Budget Week Dinner at Parliament House                                  | $500            |
+| LIB                                         | Lib-FED Menzies Research Centre - NSW                                              | $500            |
+| LIB                                         | LIB-VIC Sandringham Electorate Conference                                          | $500            |
+| LIB                                         | Liberal National Party LNP-QLD (The Platinum Circle)                               | $500            |
+| LIB                                         | Liberal National Party Qld/LNP-QLD                                                 | $500            |
+| LIB                                         | Liberal Part of Australia SA Division- Dunstan                                     | $500            |
+| LIB                                         | Liberal Party NSW Division - Bega                                                  | $500            |
+| LIB                                         | Liberal Party NSW Division - Cronulla                                              | $500            |
+| LIB                                         | Liberal Party NSW Division - Hornsby                                               | $500            |
+| LIB                                         | Liberal Party NSW Division - Kiama                                                 | $500            |
+| LIB                                         | Liberal Party NSW Division - Lindsay                                               | $500            |
+| LIB                                         | Liberal Party NSW Division - Maitland                                              | $500            |
+| LIB                                         | Liberal Party NSW Division - Murrumbidgee                                          | $500            |
+| LIB                                         | Liberal Party NSW Division - Oatley                                                | $500            |
+| LIB                                         | Liberal Party NSW Division - Pittwater                                             | $500            |
+| LIB                                         | Liberal Party NSW Division - Ryde                                                  | $500            |
+| LIB                                         | Liberal Party NSW Division - Vaucluse                                              | $500            |
+| LIB                                         | Liberal Party NSW/LIB-NSW                                                          | $500            |
+| LIB                                         | Liberal Party of Aus-SA - LIB-SA                                                   | $500            |
+| LIB                                         | Liberal Party of Aust - Wakehurst Cromer                                           | $500            |
+| LIB                                         | Liberal Party of Australia - Wentworth FEC                                         | $500            |
+| LIB                                         | Liberal Party of Australia (Lib-FED) (Bega SE)                                     | $500            |
+| LIB                                         | Liberal Party of Australia LIB-QLD                                                 | $500            |
+| LIB                                         | Liberal Party of Australia VIC Division - Bulleen                                  | $500            |
+| LIB                                         | Liberal Party of Australia VIC Division - Malvern                                  | $500            |
+| LIB                                         | Liberal-National Party - Leichhardt FDC                                            | $500            |
+| LIB                                         | LNP-Fairfax FDC/LNP-QLD                                                            | $500            |
+| LIB                                         | Macgregor LNP Campaign (LNP QLD)                                                   | $500            |
+| LIB                                         | NSW Liberal Forum                                                                  | $500            |
+| LIB                                         | S Marshall - LIB-SA                                                                | $500            |
+| NP                                          | National Party of Australia - NSW NAT-NSW                                          | $500            |
+| NP                                          | The Nationals - National Policy Forum - NAT-FED                                    | $500            |
+| LIB                                         | Liberal Party of Australia - ACT Division / LIB-ACT                                | $495            |
+| LIB                                         | Liberal Party NSW Division - Warringah                                             | $490            |
+| NP                                          | The National Party                                                                 | $490            |
+| ALP                                         | ALP - Robert McClelland Campaign - ALP-FED                                         | $480            |
+| ALP                                         | ALP NSW Branch - Summer Hill Campaign                                              | $454            |
+| ALP                                         | ALP SA Branch                                                                      | $454            |
+| LIB                                         | Liberal Party NSW Division - North Shore SEC                                       | $454            |
+| ALP                                         | Australian Labor Party - QLD Branch                                                | $450            |
+| ALP                                         | Hunter Federal Campaign Account (ALP - FED)                                        | $450            |
+| LIB                                         | Lib - WA: Lunch with Tony Abbott                                                   | $450            |
+| LIB                                         | LIB-NSW Bradfield Forum                                                            | $450            |
+| LIB                                         | Liberal Party NSW DIvision WSEC                                                    | $450            |
+| ALP                                         | ALP-WA (LBR)                                                                       | $440            |
+| NP                                          | NAT National Party of Australia                                                    | $440            |
+| ALP                                         | ALP VIC - Monbulk SECC                                                             | $400            |
+| ALP                                         | Australian Labor Party - Balmain State Campaign                                    | $400            |
+| ALP                                         | Chris Bowen MP Federal                                                             | $400            |
+| LIB                                         | LIB-VIC Enterprise 500 Vic - 2014 Enterprise 500 Victorian Annual Dinner           | $400            |
+| LIB                                         | Liberal National Party of Queensland - Maiwar                                      | $400            |
+| ALP                                         | Emily's List SA (ALP-FED)                                                          | $375            |
+| ALP                                         | ALP - QLD (2016 State Budget event)                                                | $352            |
+| CEC                                         | CJPW Budget Night - Opposition Reply to the Budget                                 | $350            |
+| LIB                                         | CJPW (LIB-FED)                                                                     | $350            |
+| LIB                                         | Lib - NSW: Cook 200 Club Annual Membership                                         | $350            |
+| LIB                                         | LIB-VIC Enterprise 500 Victoria                                                    | $350            |
+| NP                                          | National Party of Australia NSW Leaders Forum                                      | $330            |
+| LIB                                         | Liberal Party of NSW Division - Wentworth                                          | $328            |
+| NP                                          | NAT - WA (Business event)                                                          | $320            |
+| LIB                                         | LIB-VIC Forest Hill Supporters Club                                                | $315            |
+|                                             | Blaxland Campaign Fundraising Dinner                                               | $300            |
+| LIB                                         | Lib - SA: SEC Twilight Gold Day                                                    | $300            |
+| LIB                                         | LIB-SA, Norwood SEC                                                                | $300            |
+| LIB                                         | LIB-VIC Kooyong Federal Electorate Conference                                      | $300            |
+| LIB                                         | LNP-QLD - Q Forum Event                                                            | $300            |
+| LIB                                         | Mosman Liberal Party Dinner / LIB-NSW                                              | $300            |
+| LIB                                         | LNP--QLD                                                                           | $297            |
+| LIB                                         | LIB (Hon. Joe Hockey talks to Spectator)                                           | $275            |
+| LIB                                         | LIB-TAS (Petrusma)                                                                 | $275            |
+| LIB                                         | Liberal Party of Australia - SA Division (Hindmarsh FEC)                           | $272            |
+| ALP                                         | ALP - QLD                                                                          | $264            |
+| LIB                                         | LIB-SA, Adelaide SEC                                                               | $260            |
+| ALP                                         | ALP - VIC: Donation to ALP Victoria Branch                                         | $250            |
+| ALP                                         | ALP East Hills Campaign Account                                                    | $250            |
+| GRN                                         | GRN                                                                                | $250            |
+| GRN                                         | GRN - VIC                                                                          | $250            |
+| LIB                                         | Deakin Executive Forum LIB-VIC                                                     | $250            |
+| LIB                                         | LIB-SA, Bragg SEC                                                                  | $250            |
+| LIB                                         | LIB-VIC Dunkley Electorate Conference                                              | $250            |
+| LIB                                         | Liberal Party (Torrens SEC)                                                        | $250            |
+| LIB                                         | LIberal Party NSW Division - Cook                                                  | $250            |
+| LIB                                         | Liberal Party NSW Division - Lindsay                                               | $250            |
+| LIB                                         | Liberal Party of Australia - Cook                                                  | $250            |
+| LIB                                         | Liberal Party of Australia - Wakehurst SEC                                         | $250            |
+| LIB                                         | Liberal Party of Australia (NSW) Nth Syd FEC                                       | $250            |
+| LIB                                         | Liberal Party of Australia NSW Division - North Sydney FEC                         | $250            |
+| LIB                                         | Liberal Party of Australia SA - Bragg SEC                                          | $250            |
+| LIB                                         | North Sydney FEC (LIB-FED)                                                         | $250            |
+| LIB                                         | North West 200 Club                                                                | $250            |
+| NP                                          | NATS-NSW                                                                           | $250            |
+| ALP                                         | Australian Labor Party - Kingston FEC                                              | $245            |
+| LIB                                         | Liberal Party of Australia NSW Division - Goulburn                                 | $245            |
+| LIB                                         | LIB-VIC Kew State Electorate Conference                                            | $243            |
+|                                             | North East TLC                                                                     | $240            |
+| ALP                                         | ALP NSW Branch - Roberston Campaign                                                | $227            |
+| LIB                                         | Lib - SA: Auge Dinner                                                              | $225            |
+| NP                                          | National Party of Australia - Victoria - NAT-VIC                                   | $220            |
+| NP                                          | The Nationals for Regional Australia (The Page Research Centre Ltd)                | $220            |
+| LIB                                         | Liberal Party of Australia - Don Dunstan Foundation                                | $211            |
+| ALP                                         | ALP-NSW Branch - Watson Federal Camp                                               | $200            |
+| ALP                                         | Aust Labor Party-Kingsgrove-Watson Fed                                             | $200            |
+| ALP                                         | Country Labor Party / CLR-NSW                                                      | $200            |
+| GRN                                         | The Territory Green Party                                                          | $200            |
+| LIB                                         | Lib - VIC: Dinner celebrating 1992 Victory                                         | $200            |
+| LIB                                         | LIB (VIC) (Dinner held by Enterprise 500)                                          | $200            |
+| LIB                                         | Liberal Part of Australia SA Division - Colton                                     | $200            |
+| LIB                                         | Liberal Part of Australia SA Division - Unley                                      | $200            |
+| LIB                                         | Liberal Party of Aus-Vaucluse Conf                                                 | $200            |
+| LIB                                         | Liberal Party of Austalia - SA - LIB-SA                                            | $200            |
+| LIB                                         | Liberal Party of Australia - Davidson SEC                                          | $200            |
+| LIB                                         | Liberal Party of Australia - Unley SEC                                             | $195            |
+| ALP                                         | ALP - Barton and Hughes Campaign                                                   | $182            |
+| LIB                                         | LNP-QLD - Function attendance                                                      | $182            |
+| LIB                                         | LNP-QLD - QLD State Budget lunch                                                   | $182            |
+| LIB                                         | Fed Election 2010 Countdown Dinner - Sen Fierravanti-Wells / LIB-NSW               | $180            |
+| LIB                                         | LIB-VIC Deakin 200 Club                                                            | $175            |
+| LIB                                         | LIB-SA (Mawson Fundraiser)                                                         | $170            |
+| LIB                                         | Sturt Federal Electoral Committee                                                  | $165            |
+| LIB                                         | Sturt Federal Electorate Committee                                                 | $165            |
+| LIB                                         | Sturt Federal Electorate Committee - LIB-SA                                        | $165            |
+| LIB                                         | Liberal Party - Tony Smith MP Lunch / LIB-FED                                      | $160            |
+| LIB                                         | Platinum Forum LIB-VIC                                                             | $160            |
+| LIB                                         | LIB-VIC Deakin Federal Electorate Conference                                       | $155            |
+|                                             | Bradfield Federal Electrate Conf-NSW                                               | $150            |
+| ALP                                         | ALP-SA (EOY drinks w/ Premier + ALP)                                               | $150            |
+| LIB                                         | 2009 Ku-ring-gai Business Breakfast                                                | $150            |
+| LIB                                         | Lib - NSW: Federal Fundraising Dinner                                              | $150            |
+| LIB                                         | Lib - SA: Luncheon with Marshall & Kennett                                         | $150            |
+| LIB                                         | LIB-NSW (2013 Fed Election Countdown Dinner)                                       | $150            |
+| LIB                                         | LIB-NSW (2013 Fed Election Countdown)                                              | $150            |
+| LIB                                         | LIB-SA (Ladies Lunch 2013)                                                         | $150            |
+| LIB                                         | LNP-QLD - Q Forum Women of Influence Event                                         | $150            |
+| LIB                                         | Sturt Liberal FEC (LIB-FED)                                                        | $150            |
+| NP                                          | National Party of Australia - NSW (NAT - NSW)                                      | $150            |
+| NP                                          | Nationals (NSW)                                                                    | $150            |
+| ALP                                         | ALP-SA (Lunch with Julia Gillard)                                                  | $130            |
+| ALP                                         | ALP-ACT: Testimonial Dinner                                                        | $125            |
+| ALP                                         | ALP-SA (Celebrate Hon John Hill career)                                            | $125            |
+| LIB                                         | Liberal Party NSW Division - Member for Ku-ring-gai                                | $125            |
+| LIB                                         | Lib - NSW: Tony Abbott Birthday Function                                           | $120            |
+| LIB                                         | Liberal Party of NSW - LIB-NSW                                                     | $120            |
+| LIB                                         | LPA - LIB-NSW                                                                      | $120            |
+| LIB                                         | Dame Pattie Menzies Foundation Trust                                               | $120            |
+| ALP                                         | Matt Brown                                                                         | $110            |
+| LIB                                         | Liberal Party of Australia - Epping SEC                                            | $110            |
+| LIB                                         | LNP-QLD The Platinum Circle                                                        | $110            |
+| NP                                          | NAT - WA                                                                           | $110            |
+| NP                                          | National Party of Australia - NSW - NAT-NSW                                        | $110            |
+|                                             | McMillan FEA                                                                       | $100            |
+| ALP                                         | Australian Labor Party - QLD                                                       | $100            |
+| GRN                                         | GRN - FED                                                                          | $100            |
+| LIB                                         | Chisholm Electorate Conference LIB-VIC                                             | $100            |
+| LIB                                         | Lib - SA: Leadership on the Couch                                                  | $100            |
+| LIB                                         | Lib - WA: Campaign Raffle                                                          | $100            |
+| LIB                                         | LIB-SA (Cocktails with Sen. Hon. Eric Abetz)                                       | $100            |
+| LIB                                         | LIB-VIC (2013 Spring Evening Briefing)                                             | $100            |
+| LIB                                         | LIB-VIC Southern Metropolitan Electorate Conference                                | $100            |
+| LIB                                         | Liberal Party NSW Division - Davidson                                              | $100            |
+| LIB                                         | Liberal Party of Australia (WA)                                                    | $100            |
+| LIB                                         | Liberal Party Davidson (LIB-NSW)                                                   | $95             |
+| LIB                                         | Liberal Party NSW Division - Bradfield                                             | $95             |
+| LIB                                         | Liberal Party of Australia - Bradfield Forum - LIB-NSW                             | $95             |
+| LIB                                         | Willoughby SEC / LIB-NSW                                                           | $90             |
+| LIB                                         | Liberal Party of Australia SA - Unley                                              | $85             |
+| LIB                                         | Liberal Party Australia - Bradfield Forum - LIB-NSW                                | $80             |
+| LIB                                         | LIB-WA - Economic Forum                                                            | $75             |
+| LIB                                         | Liberal Party of Australia - Sydney CMP                                            | $75             |
+| LIB                                         | Lib - SA: Pyne 20th event                                                          | $70             |
+| LIB                                         | Liberal Party SA - Sturt FEC                                                       | $70             |
+| LIB                                         | LIB-VIC South Metropolitan Electorate Conference                                   | $65             |
+| ALP                                         | Australian Labor Party (State of Queensland) ALP-QLD                               | $63             |
+| LIB                                         | Liberal Forum NSW                                                                  | $60             |
+| LIB                                         | Liberal Party NSW Division - Cook 200 Club                                         | $60             |
+| LIB                                         | LIB-VIC Box Hill Branch [105]                                                      | $55             |
+| LIB                                         | Liberal Party of Australia - Menzies Research - LIB-NSW                            | $55             |
+|                                             | Mt Waverley State Electorate Conference                                            | $50             |
+| ALP                                         | ALP - ALP Ministerial Forum - Sydney                                               | $50             |
+| LIB                                         | Lib - NSW                                                                          | $50             |
+| LIB                                         | LIB-VIC Malvern State Electorate Conference                                        | $50             |
+| NP                                          | National Party of Australia - N.S.W. / NAT-NSW                                     | $50             |
+| LIB                                         | Liberal Party WA - Riverton Campaign                                               | $35             |


### PR DESCRIPTION
Reviewing the diff, it seems as though the **ordering of donations of the same value may have changed**. It seems unlikely that this would upset the engine.

Looking for feedback that this update doesn't hurt output, happy to reorg to match if necessary.

---
99.986% accounted for. Of total $596,298,520 only $80,741 / 52 records are uncategorised. Mostly seem to be misrecording (SECC)

Aiming for labelling that would be useful/googleable in a tweet if you add "australian political party" to it.

Unclassified:

``` The Aged and Disability Pensioners Party - VIC                                     |	 $3,500          
 Australian Reform Party - NATIONAL                                                 |	 $3,000          
 Melbourne SECC                                                                     |	 $3,000          
 Mitcham SECC                                                                       |	 $3,000          
 New England FRC Nat-Fed                                                            |	 $3,000          
 Ripon SECC                                                                         |	 $3,000          
 Seymour SECC                                                                       |	 $3,000          
 Wills FEA                                                                          |	 $3,000          
 CLR-NSW                                                                            |	 $2,850          
 Baulkham Hills SEC                                                                 |	 $2,500          
 The Bradfield Forum                                                                |	 $2,500          
 Wollondilly                                                                        |	 $2,500          
 Australia First Party - NATIONAL                                                   |	 $2,000          
 Ballarat Election Campaign                                                         |	 $2,000          
 Barton & Hughes Fedrral Campaign Account. (Joint)                                  |	 $2,000          
 Forrest Campaign Account                                                           |	 $2,000          
 Greek Aust Conservative Coalition                                                  |	 $2,000          
 Holland Park MEC                                                                   |	 $2,000          
 Kogarah                                                                            |	 $2,000          
 Mayo Federal Electorate Convention                                                 |	 $2,000          
 Nuclear Disarmament Party of Australia - NATIONAL                                  |	 $2,000          
 Robert Oakshott                                                                    |	 $2,000          
 NBLF on Sustainable Development                                                    |	 $1,855          
 Queensland Research Pty Ltd                                                        |	 $1,700          
 Bundoora SECC                                                                      |	 $1,500          
 Londonderry                                                                        |	 $1,500          
 Non-Custodial Parents Party - NATIONAL                                             |	 $1,500          
 Hughes Federal Campaign Account                                                    |	 $1,100          
 The Endeavour Consulting Group                                                     |	 $1,100          
 Brett Murray                                                                       |	 $1,000          
 Chesterfield Evans                                                                 |	 $1,000          
 Lang Holdings Aust Pty Ltd                                                         |	 $1,000          
 Marrickville State Campaign                                                        |	 $1,000          
 Max Christmas Camp                                                                 |	 $1,000          
 Granville                                                                          |	 $900            
 Keira                                                                              |	 $800            
 North Sydney FEC                                                                   |	 $800            
 Duncan Gay - NAT - NSW                                                             |	 $750            
 Bradfield Forum                                                                    |	 $550            
 Endeavour Business Forum                                                           |	 $550            
 Andrew Fraser - NAT - NSW                                                          |	 $500            
 Cook Endeavour Forum                                                               |	 $500            
 Daryl Williams                                                                     |	 $500            
 Gippsland TLC                                                                      |	 $500            
 Helen Coonan                                                                       |	 $500            
 North Sydney FEC Campaign Fund                                                     |	 $500            
 Salvatore Scevola                                                                  |	 $500            
 Blaxland Campaign Fundraising Dinner                                               |	 $300            
 North East TLC                                                                     |	 $240            
 Bradfield Federal Electrate Conf-NSW                                               |	 $150            
 McMillan FEA                                                                       |	 $100            
 Mt Waverley State Electorate Conference                                            |	 $50             
```